### PR TITLE
Properly handle absence of the Coq-LSP in UI and allow modifying its standard location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.0
+
+### Public changes
+
+- Allow manually modifying the location of the `coq-lsp` executable in the settings. This is useful when the `coq-lsp` executable is not in the PATH. Alongside, correctly handle the case when the `coq-lsp` executable is not found.
+
 ## 2.2.5
 
 - Contribute the new benchmarking report for 300 theorems. 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This extension contributes the following settings:
 
 * `coqpilot.contextTheoremsRankerType` : The type of theorems ranker that will be used to select theorems for proof generation (when context is smaller than taking all of them). Either randomly, by Jacard index (similarity metric) or by distance from the theorem, with the currently observed admit. 
 * `coqpilot.loggingVerbosity` : Verbosity of the logs. Could be `info`, `debug`.
+* `coqpilot.coqLspServerPath` : Path to the coq-lsp server. By default, it is set to `coq-lsp`.
 
 * `coqpilot.predefinedProofsModelsParameters`, `coqpilot.openAiModelsParameters`, `coqpilot.grazieModelsParameters` and `coqpilot.lmStudioModelsParameters`:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - 🔍 [Brief Technical Overview](#brief-technical-overview)
 - 💡 [Example Usage](#example-usage)
 - 🛠 [Installation](#installation)
-  - ▶️ [Coq-lsp Installation](#coq-lsp-installation)
+  - ▶️ [Coq-LSP Installation](#coq-lsp-installation)
   - 🤖 [Building Locally](#building-locally)
 - ⚠️ [Important Information](#important)
 - ⚙️ [Extension Settings](#extension-settings)
@@ -62,16 +62,18 @@ As soon as at least one valid proof is found, it is substituted in the editor an
 
 ## Installation
 
-### Coq-lsp installation
+### Coq-LSP installation
 
-To make the extension running you will have to install `coq-lsp` server. You can install it using opam: 
+To run the extension, you must install a `coq-lsp` server. Depending on the system used in your project, you should install it using `opam` or `nix`. A well-configured `nix` project should have the `coq-lsp` server installed as a dependency. To install `coq-lsp` using `opam`, you can use the following commands: 
 ```bash
 opam pin add coq-lsp 0.1.8+8.19.0
 opam install coq-lsp
 ```
 For more information on how to install `coq-lsp` please refer to [coq-lsp](https://github.com/ejgallego/coq-lsp). 
 
-With coq-lsp, extension should have everything it needs to run.
+Either way around, if the [coq-lsp](https://github.com/ejgallego/coq-lsp) extension works well and you can see the goals and theorems in the VSCode, then `CoqPilot` should work as well. However, using [coq-lsp](https://github.com/ejgallego/coq-lsp) as a plugin for Coq support is not mandatory for `CoqPilot` to work.
+
+If your installation of `coq-lsp` is not in the default path, you can specify the path to the `coq-lsp` server in the settings using the `coqpilot.coqLspServerPath` setting. Default value should work well for most of the cases.
 
 ### Building locally
 
@@ -93,7 +95,7 @@ npm install
 npm run compile
 ```
 
-To run the extension from the vscode, you can press `F5` or click on `Run extension` in the `Run and Debug` section. It will open a new window with the extension running.
+To run the extension from the VSCode, you can press `F5` or click on `Run extension` in the `Run and Debug` section. It will open a new window with the extension running.
 
 To run all tests properly (i.e. with rebuilding the resources and the code first), execute the following task:
 ```bash
@@ -117,7 +119,7 @@ chmod +x set_gitignore.sh
 ./set_gitignore.sh
 ```
 It will add the format of CoqPilot aux files to your global gitignore file on the system, so that even if CoqPilot forgets to clean files up, they will not be marked as new files in git.
-Comment: Such files are not visible in the vscode explorer, because plugin adds them to the `files.exclude` setting on startup.
+Comment: Such files are not visible in the VSCode explorer, because plugin adds them to the `files.exclude` setting on startup.
 
 ## Extension Settings
 
@@ -228,7 +230,7 @@ First things first, the process of running the benchmark is not perfectly automa
     cachix use weakmemory
     ```
 
-3. Go to the `imm` subdirectory, apply the nix environment (without it the project will NOT build) and build the project: 
+3. Go to the `imm` subdirectory, apply the nix environment (without it the project will **NOT** build) and build the project: 
     ```bash
     cd dataset/imm 
     nix-build

--- a/package.json
+++ b/package.json
@@ -358,6 +358,12 @@
             "description": "The verbosity of the logs.",
             "default": "info",
             "order": 5
+          },
+          "coqpilot.coqLspServerPath": {
+            "type": "string",
+            "description": "Path to the Coq LSP server. If not specified, CoqPilot will try to find the server automatically at the default location: coq-lsp at PATH.",
+            "default": "coq-lsp",
+            "order": 6
           }
         }
       }

--- a/src/coqLsp/coqLspConnector.ts
+++ b/src/coqLsp/coqLspConnector.ts
@@ -67,6 +67,7 @@ export class CoqLspConnector extends LanguageClient {
                 let emsg = error.toString();
                 this.eventLogger?.log("coq-lsp-start-error", emsg);
                 this.logStatusUpdate("stopped");
+                throw error;
             });
     }
 

--- a/src/coqLsp/coqLspTypes.ts
+++ b/src/coqLsp/coqLspTypes.ts
@@ -156,3 +156,13 @@ export class CoqLspError extends Error {
         this.name = "CoqLspError";
     }
 }
+
+export class CoqLspStartupError extends Error {
+    constructor(
+        message: string,
+        public readonly path: string
+    ) {
+        super(message);
+        this.name = "CoqLspStartupError";
+    }
+}

--- a/src/coqLsp/coqLspTypes.ts
+++ b/src/coqLsp/coqLspTypes.ts
@@ -157,10 +157,27 @@ export class CoqLspError extends Error {
     }
 }
 
-export class CoqLspStartupError extends Error {
+export class CoqParsingError extends CoqLspError {
     constructor(
         message: string,
-        public readonly path: string
+        public data?: any
+    ) {
+        super(message);
+        this.name = "CoqParsingError";
+    }
+}
+
+export class CoqLspTimeoutError extends CoqLspError {
+    constructor(message: string) {
+        super(message);
+        this.name = "CoqLspTimeoutError";
+    }
+}
+
+export class CoqLspStartupError extends CoqLspError {
+    constructor(
+        message: string,
+        readonly path: string
     ) {
         super(message);
         this.name = "CoqLspStartupError";

--- a/src/coqParser/parseCoqFile.ts
+++ b/src/coqParser/parseCoqFile.ts
@@ -2,7 +2,11 @@ import { readFileSync } from "fs";
 import { Position, Range } from "vscode-languageclient";
 
 import { CoqLspClient } from "../coqLsp/coqLspClient";
-import { FlecheDocument, RangedSpan } from "../coqLsp/coqLspTypes";
+import {
+    CoqParsingError,
+    FlecheDocument,
+    RangedSpan,
+} from "../coqLsp/coqLspTypes";
 
 import { Uri } from "../utils/uri";
 
@@ -25,15 +29,6 @@ export async function parseCoqFile(
                 `failed to parse file with Error: ${error.message}`
             );
         });
-}
-
-export class CoqParsingError extends Error {
-    constructor(
-        public message: string,
-        public data?: any
-    ) {
-        super(message);
-    }
 }
 
 function parseFlecheDocument(

--- a/src/core/completionGenerator.ts
+++ b/src/core/completionGenerator.ts
@@ -7,6 +7,7 @@ import { ModelsParams } from "../llm/llmServices/modelParams";
 import { ProofGenerationContext } from "../llm/proofGenerationContext";
 
 import { Goal, Hyp, PpString } from "../coqLsp/coqLspTypes";
+import { CoqLspTimeoutError } from "../coqLsp/coqLspTypes";
 
 import { Theorem } from "../coqParser/parsedTypes";
 import { EventLogger } from "../logging/eventLogger";
@@ -14,11 +15,7 @@ import { createCoqLspClient } from "../test/commonTestFunctions/coqLspBuilder";
 import { stringifyAnyValue } from "../utils/printers";
 
 import { ContextTheoremsRanker } from "./contextTheoremRanker/contextTheoremsRanker";
-import {
-    CoqLspTimeoutError,
-    CoqProofChecker,
-    ProofCheckResult,
-} from "./coqProofChecker";
+import { CoqProofChecker, ProofCheckResult } from "./coqProofChecker";
 
 export interface CompletionContext {
     proofGoal: Goal<PpString>;

--- a/src/core/completionGenerator.ts
+++ b/src/core/completionGenerator.ts
@@ -242,7 +242,7 @@ async function checkGeneratedProofs(
 
     if (workspaceRootPath) {
         processEnvironment.coqProofChecker.dispose();
-        const client = createCoqLspClient(workspaceRootPath);
+        const client = await createCoqLspClient(workspaceRootPath);
         const coqProofChecker = new CoqProofChecker(client);
         processEnvironment.coqProofChecker = coqProofChecker;
     }

--- a/src/core/coqProofChecker.ts
+++ b/src/core/coqProofChecker.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { Position } from "vscode-languageclient";
 
 import { CoqLspClient } from "../coqLsp/coqLspClient";
+import { CoqLspTimeoutError } from "../coqLsp/coqLspTypes";
 
 import { Uri } from "../utils/uri";
 
@@ -24,13 +25,6 @@ export interface CoqProofCheckerInterface {
     ): Promise<ProofCheckResult[]>;
 
     dispose(): void;
-}
-
-export class CoqLspTimeoutError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = "CoqLspTimeoutError";
-    }
 }
 
 export class CoqProofChecker implements CoqProofCheckerInterface {

--- a/src/extension/configReaders.ts
+++ b/src/extension/configReaders.ts
@@ -26,12 +26,23 @@ import { AjvMode, buildAjv } from "../utils/ajvErrorsHandling";
 import { stringifyAnyValue, stringifyDefinedValue } from "../utils/printers";
 
 import { pluginId } from "./coqPilot";
-import { EditorMessages } from "./editorMessages";
+import {
+    EditorMessages,
+    showMessageToUserWithSettingsHint,
+} from "./editorMessages";
 import {
     SettingsValidationError,
-    showMessageToUserWithSettingsHint,
     toSettingName,
 } from "./settingsValidationError";
+
+export function parseCoqLspServerPath(): string {
+    const workspaceConfig = workspace.getConfiguration(pluginId);
+    const coqLspServerPath = workspaceConfig.get("coqLspServerPath");
+    if (typeof coqLspServerPath !== "string") {
+        throw new Error("coqLspServerPath is not properly configured");
+    }
+    return coqLspServerPath;
+}
 
 export function buildTheoremsRankerFromConfig(): ContextTheoremsRanker {
     const workspaceConfig = workspace.getConfiguration(pluginId);

--- a/src/extension/coqPilot.ts
+++ b/src/extension/coqPilot.ts
@@ -9,6 +9,7 @@ import {
 
 import { CoqLspClient } from "../coqLsp/coqLspClient";
 import { CoqLspConfig } from "../coqLsp/coqLspConfig";
+import { CoqLspStartupError } from "../coqLsp/coqLspTypes";
 
 import { generateCompletion } from "../core/completionGenerator";
 import {
@@ -29,6 +30,7 @@ import { Uri } from "../utils/uri";
 
 import {
     buildTheoremsRankerFromConfig,
+    parseCoqLspServerPath,
     readAndValidateUserModelsParams,
 } from "./configReaders";
 import {
@@ -37,7 +39,11 @@ import {
     insertCompletion,
 } from "./documentEditor";
 import { suggestAddingAuxFilesToGitignore } from "./editGitignoreCommand";
-import { EditorMessages, showMessageToUser } from "./editorMessages";
+import {
+    EditorMessages,
+    showMessageToUser,
+    showMessageToUserWithSettingsHint,
+} from "./editorMessages";
 import { GlobalExtensionState } from "./globalExtensionState";
 import { subscribeToHandleLLMServicesEvents } from "./llmServicesEventsHandler";
 import {
@@ -116,6 +122,12 @@ export class CoqPilot {
                 } catch (error) {
                     if (error instanceof SettingsValidationError) {
                         error.showAsMessageToUser();
+                    } else if (error instanceof CoqLspStartupError) {
+                        showMessageToUserWithSettingsHint(
+                            EditorMessages.coqLspStartupFailure(error.path),
+                            "error",
+                            `${pluginId}.coqLspServerPath`
+                        );
                     } else if (error instanceof Error) {
                         showMessageToUser(
                             EditorMessages.errorOccurred(error.message),
@@ -239,8 +251,13 @@ export class CoqPilot {
     > {
         const fileUri = Uri.fromPath(filePath);
         const coqLspServerConfig = CoqLspConfig.createServerConfig();
-        const coqLspClientConfig = CoqLspConfig.createClientConfig();
-        const client = new CoqLspClient(coqLspServerConfig, coqLspClientConfig);
+        const coqLspServerPath = parseCoqLspServerPath();
+        const coqLspClientConfig =
+            CoqLspConfig.createClientConfig(coqLspServerPath);
+        const client = await CoqLspClient.create(
+            coqLspServerConfig,
+            coqLspClientConfig
+        );
         const contextTheoremsRanker = buildTheoremsRankerFromConfig();
 
         const coqProofChecker = new CoqProofChecker(client);

--- a/src/extension/editorMessages.ts
+++ b/src/extension/editorMessages.ts
@@ -1,10 +1,14 @@
 import { DefinedError } from "ajv";
-import { window } from "vscode";
+import { commands, window } from "vscode";
 
 import { Time } from "../llm/llmServices/utils/time";
 
 import { ajvErrorsAsString } from "../utils/ajvErrorsHandling";
 import { stringifyAnyValue } from "../utils/printers";
+
+import { pluginId } from "./coqPilot";
+
+export const openSettingsItem = "Open settings";
 
 export namespace EditorMessages {
     export const timeoutExceeded =
@@ -15,6 +19,9 @@ export namespace EditorMessages {
 
     export const errorOccurred = (errorMessage: string) =>
         `CoqPilot got an error: ${errorMessage}. Please make sure the environment is properly set and the plugin is configured correctly. For more information, see the README: https://github.com/JetBrains-Research/coqpilot/blob/main/README.md. If the error appears to be a bug, please report it by opening an issue in the CoqPilot GitHub repository.`;
+
+    export const coqLspStartupFailure = (pathToServer: string) =>
+        `CoqPilot failed to start the Coq LSP server at path "${pathToServer}". Please make sure the path is correct and the server is properly installed. If your installation is not in a standard location, please set the path to the server in the settings.`;
 
     export const serviceBecameUnavailable = (
         serviceName: string,
@@ -121,4 +128,19 @@ function formatTimeToUIString(time: Time): string {
 function formatTimeItem(value: number, name: string): string {
     const suffix = value === 1 ? "" : "s";
     return `${value} ${name}${suffix}`;
+}
+
+export function showMessageToUserWithSettingsHint(
+    message: string,
+    severity: UIMessageSeverity,
+    settingToOpenName: string = pluginId
+) {
+    showMessageToUser(message, severity, openSettingsItem).then((value) => {
+        if (value === openSettingsItem) {
+            commands.executeCommand(
+                "workbench.action.openSettings",
+                settingToOpenName
+            );
+        }
+    });
 }

--- a/src/extension/llmServicesEventsHandler.ts
+++ b/src/extension/llmServicesEventsHandler.ts
@@ -16,11 +16,12 @@ import { EventLogger } from "../logging/eventLogger";
 import { stringifyAnyValue } from "../utils/printers";
 import { SimpleSet } from "../utils/simpleSet";
 
-import { EditorMessages, showMessageToUser } from "./editorMessages";
 import {
+    EditorMessages,
+    showMessageToUser,
     showMessageToUserWithSettingsHint,
-    toSettingName,
-} from "./settingsValidationError";
+} from "./editorMessages";
+import { toSettingName } from "./settingsValidationError";
 
 enum LLMServiceAvailablityState {
     AVAILABLE,

--- a/src/extension/settingsValidationError.ts
+++ b/src/extension/settingsValidationError.ts
@@ -1,12 +1,11 @@
-import { commands } from "vscode";
-
 import { switchByLLMServiceType } from "../llm/llmServices";
 import { LLMService } from "../llm/llmServices/llmService";
 
 import { pluginId } from "./coqPilot";
-import { UIMessageSeverity, showMessageToUser } from "./editorMessages";
-
-export const openSettingsItem = "Open settings";
+import {
+    UIMessageSeverity,
+    showMessageToUserWithSettingsHint,
+} from "./editorMessages";
 
 export class SettingsValidationError extends Error {
     constructor(
@@ -25,21 +24,6 @@ export class SettingsValidationError extends Error {
             this.settingToOpenName
         );
     }
-}
-
-export function showMessageToUserWithSettingsHint(
-    message: string,
-    severity: UIMessageSeverity,
-    settingToOpenName: string = pluginId
-) {
-    showMessageToUser(message, severity, openSettingsItem).then((value) => {
-        if (value === openSettingsItem) {
-            commands.executeCommand(
-                "workbench.action.openSettings",
-                settingToOpenName
-            );
-        }
-    });
 }
 
 export function toSettingName(llmService: LLMService<any, any>): string {

--- a/src/test/benchmark/benchmarkingFramework.ts
+++ b/src/test/benchmark/benchmarkingFramework.ts
@@ -383,7 +383,7 @@ async function prepareForBenchmarkCompletions(
 
     const [fileUri, isNew] = getFileUriWithImports(filePath, additionalImports);
 
-    const client = createCoqLspClient(workspaceRootPath);
+    const client = await createCoqLspClient(workspaceRootPath);
     await client.openTextDocument(fileUri);
 
     const coqProofChecker = new CoqProofChecker(client);
@@ -417,13 +417,15 @@ async function prepareForBenchmarkCompletions(
     return [completionTargets, sourceFileEnvironment, processEnvironment];
 }
 
-function createCoqLspClient(workspaceRootPath?: string): CoqLspClient {
+async function createCoqLspClient(
+    workspaceRootPath?: string
+): Promise<CoqLspClient> {
     const coqLspServerConfig = CoqLspConfig.createServerConfig();
     const coqLspClientConfig = CoqLspConfig.createClientConfig(
         process.env.COQ_LSP_PATH || "coq-lsp",
         workspaceRootPath
     );
-    return new CoqLspClient(coqLspServerConfig, coqLspClientConfig);
+    return await CoqLspClient.create(coqLspServerConfig, coqLspClientConfig);
 }
 
 async function extractCompletionTargets(

--- a/src/test/commonTestFunctions/coqFileParser.ts
+++ b/src/test/commonTestFunctions/coqFileParser.ts
@@ -15,7 +15,7 @@ export async function parseTheoremsFromCoqFile(
     );
 
     const fileUri = Uri.fromPath(filePath);
-    const client = createCoqLspClient(rootDir);
+    const client = await createCoqLspClient(rootDir);
 
     await client.openTextDocument(fileUri);
     const document = await parseCoqFile(fileUri, client);

--- a/src/test/commonTestFunctions/coqLspBuilder.ts
+++ b/src/test/commonTestFunctions/coqLspBuilder.ts
@@ -1,12 +1,14 @@
 import { CoqLspClient } from "../../coqLsp/coqLspClient";
 import { CoqLspConfig } from "../../coqLsp/coqLspConfig";
 
-export function createCoqLspClient(workspaceRootPath?: string): CoqLspClient {
+export async function createCoqLspClient(
+    workspaceRootPath?: string
+): Promise<CoqLspClient> {
     const coqLspServerConfig = CoqLspConfig.createServerConfig();
     const coqLspClientConfig = CoqLspConfig.createClientConfig(
         process.env.COQ_LSP_PATH || "coq-lsp",
         workspaceRootPath
     );
 
-    return new CoqLspClient(coqLspServerConfig, coqLspClientConfig);
+    return await CoqLspClient.create(coqLspServerConfig, coqLspClientConfig);
 }

--- a/src/test/commonTestFunctions/prepareEnvironment.ts
+++ b/src/test/commonTestFunctions/prepareEnvironment.ts
@@ -34,7 +34,7 @@ export async function prepareEnvironment(
     );
     const fileUri = Uri.fromPath(filePath);
 
-    const client = createCoqLspClient(rootDir);
+    const client = await createCoqLspClient(rootDir);
     const coqProofChecker = new CoqProofChecker(client);
 
     await client.openTextDocument(fileUri);

--- a/src/test/coqLsp/coqLspGetGoals.test.ts
+++ b/src/test/coqLsp/coqLspGetGoals.test.ts
@@ -18,7 +18,7 @@ suite("Retrieve goals from Coq file", () => {
         );
         const fileUri = Uri.fromPath(filePath);
 
-        const client = createCoqLspClient(rootDir);
+        const client = await createCoqLspClient(rootDir);
         await client.openTextDocument(fileUri);
         const goals = await Promise.all(
             points.map(async (point) => {

--- a/src/test/core/coqProofChecker.test.ts
+++ b/src/test/core/coqProofChecker.test.ts
@@ -22,7 +22,7 @@ suite("`CoqProofChecker` tests", () => {
         const fileDir = path.dirname(filePath);
 
         const fileLines = readFileSync(filePath).toString().split("\n");
-        const client = createCoqLspClient(rootDir);
+        const client = await createCoqLspClient(rootDir);
         const coqProofChecker = new CoqProofChecker(client);
         const preparedProofs = proofsToCheck.map((proofs) =>
             proofs.map(prepareProofBeforeCheck)


### PR DESCRIPTION
YouTrack ISSUE: [PLAN-127](https://youtrack.jetbrains.com/issue/PLAN-127) 

Main internal change: CoqLspClient now has a private constructor and a fabric async method for construction
Reason for the change: The async `start` method of the BaseLanguageClient class was ran in the constructor and was not awaited. Thus, the only way to figure out that the client is incorrectly created/failed to start -- was afterwards, after calling its methods. As constructors in typescript are not allowed to be made async, I decided on this solution. 