### PR TITLE
Benchmarking framework hot-fixes

### DIFF
--- a/etc/docs/benchmark/BENCHMARKING_FRAMEWORK_GUIDE.md
+++ b/etc/docs/benchmark/BENCHMARKING_FRAMEWORK_GUIDE.md
@@ -40,6 +40,7 @@ This experiment must be run within the workspace environment, which the user act
 cd dataset/imm
 nix-build # builds the 'imm' project
 nix-shell # activates its environment
+export COQ_LSP_PATH=$(which coq-lsp) # sets up the proper coq-lsp server path
 cd ../..
 npm run single-workspace-benchmark
 ```

--- a/package.json
+++ b/package.json
@@ -402,6 +402,8 @@
     "presingle-workspace-benchmark": "npm run prebenchmark",
     "single-workspace-benchmark": "npm run test-executables-unsafe -- -g=\"[SourceExecutable] Single Workspace Benchmark\"",
     "benchmark": "npm run single-workspace-benchmark",
+    "prebenchmark-test": "rm -rf benchmarksOutput",
+    "benchmark-test": "npm run benchmark",
     "preteamcity-benchmark-setup": "npm run prebenchmark",
     "teamcity-benchmark-setup": "node ./out/benchmark/teamCitySetup.js",
     "teamcity-benchmark-agent": "npm run test-executables-unsafe -- -g=\"[SourceExecutable] Team City Benchmark Agent\"",

--- a/package.json
+++ b/package.json
@@ -397,7 +397,7 @@
     "preclean-test": "npm run clean && npm run rebuild-test-resources && npm run compile && npm run lint",
     "clean-test": "npm run test-only",
     "prebenchmark": "npm run preclean-test",
-    "premulti-workspace-benchmark": "npm run prebenchmark",
+    "premulti-workspaces-benchmark": "npm run prebenchmark",
     "multi-workspaces-benchmark": "node ./out/benchmark/multiWorkspacesSetup.js",
     "presingle-workspace-benchmark": "npm run prebenchmark",
     "single-workspace-benchmark": "npm run test-executables-unsafe -- -g=\"[SourceExecutable] Single Workspace Benchmark\"",

--- a/src/benchmark/framework/experiment/multiWorkspacesExperiment.ts
+++ b/src/benchmark/framework/experiment/multiWorkspacesExperiment.ts
@@ -19,6 +19,7 @@ import { AbstractExperiment, ExecutionContext } from "./abstractExperiment";
  * In summary, `MultiWorkspacesExperiment` is designed to work with multiple workspaces per run,
  * making it better suited for large benchmarking experiments.
  */
+// CRITICAL TODO: support COQ_LSP_PATH switch for the processes of different workspaces
 export class MultiWorkspacesExperiment extends AbstractExperiment {
     constructor(
         bundles: InputBenchmarkingBundle[] = [],

--- a/src/benchmark/framework/parseDataset/coqProjectParser/implementation/internalSignature.ts
+++ b/src/benchmark/framework/parseDataset/coqProjectParser/implementation/internalSignature.ts
@@ -33,8 +33,6 @@ export namespace ParseCoqProjectInternalSignature {
         export type FilePathToFileTargets = { [key: string]: FileTarget[] };
 
         export interface FileTarget {
-            // TODO: optimize - `PROVE_THEOREM` targets don't need to be requested explicitly,
-            // they will be always parsed together with the theorems
             requestType: TargetRequestType;
             /**
              * If `specificTheoremName` is undefined, this target means request on all file theorems.

--- a/src/benchmark/framework/parseDataset/coqProjectParser/implementation/parseCoqProject.ts
+++ b/src/benchmark/framework/parseDataset/coqProjectParser/implementation/parseCoqProject.ts
@@ -104,7 +104,8 @@ export namespace ParseCoqProjectImpl {
             mockDocumentVersion,
             Uri.fromPath(filePath),
             coqLspClient,
-            new AbortController().signal // abort behaviour is not supported at the parsing stage
+            new AbortController().signal, // abort behaviour is not supported at the parsing stage
+            true // TODO: pass `ContextTheoremsRanker.needsUnwrappedNotations` here to improve performance
         );
         const serializedParsedFile: SerializedParsedCoqFile = {
             serializedTheoremsByNames: packIntoMappedObject(

--- a/src/benchmark/framework/parseDataset/coqProjectParser/implementation/parseCoqProject.ts
+++ b/src/benchmark/framework/parseDataset/coqProjectParser/implementation/parseCoqProject.ts
@@ -206,15 +206,16 @@ export namespace ParseCoqProjectImpl {
         };
         switch (requestType) {
             case TargetRequestType.THEOREM_PROOF:
-                return [
-                    await targetBuilder(
-                        extractSerializedTheoremFisrtProofStep(
-                            serializedTheorem
-                        ),
-                        TargetType.PROVE_THEOREM,
-                        serializedTheorem.initial_goal
-                    ),
-                ];
+                const theoremProofTarget = await targetBuilder(
+                    extractSerializedTheoremFisrtProofStep(serializedTheorem),
+                    TargetType.PROVE_THEOREM,
+                    serializedTheorem.initial_goal
+                );
+                if (serializedTheorem.initial_goal === undefined) {
+                    serializedTheorem.initial_goal =
+                        theoremProofTarget.goalToProve;
+                }
+                return [theoremProofTarget];
             case TargetRequestType.ALL_ADMITS:
                 const parsedTargets = [];
                 for (const holeProofStep of serializedTheorem.proof!.holes) {

--- a/src/benchmark/framework/parseDataset/coqProjectParser/implementation/parseCoqProject.ts
+++ b/src/benchmark/framework/parseDataset/coqProjectParser/implementation/parseCoqProject.ts
@@ -99,15 +99,11 @@ export namespace ParseCoqProjectImpl {
         logger: Logger
     ): Promise<SerializedParsedCoqFile> {
         const mockDocumentVersion = 1;
-        // TODO: [@Gleb Solovev] Do not create this Abort Controller but pass
-        // the one created at the top
-        // TODO + check coq-lsp creation in benchmarks
-        const abortController = new AbortController();
         const sourceFileEnvironment = await createSourceFileEnvironment(
             mockDocumentVersion,
             Uri.fromPath(filePath),
             coqLspClient,
-            abortController.signal
+            new AbortController().signal // abort behaviour is not supported at the parsing stage
         );
         const serializedParsedFile: SerializedParsedCoqFile = {
             serializedTheoremsByNames: packIntoMappedObject(

--- a/src/benchmark/framework/structures/common/inputTargets.ts
+++ b/src/benchmark/framework/structures/common/inputTargets.ts
@@ -259,6 +259,7 @@ export abstract class FileTarget implements EqualTo<FileTarget> {
     abstract equalTo(other: FileTarget): boolean;
     abstract hash(): number;
     abstract toString(linePrefix: string, itemizeString: string): string;
+    // TODO: support `needsTheoremInitialGoals` here to improve parsing performance
 }
 
 export class SpecificTheoremTarget extends FileTarget {

--- a/src/core/inspectSourceFile.ts
+++ b/src/core/inspectSourceFile.ts
@@ -18,7 +18,7 @@ export async function inspectSourceFile(
     fileUri: Uri,
     client: CoqLspClient,
     abortSignal: AbortSignal,
-    needsTheoremInitialGoals: boolean = true,
+    needsTheoremInitialGoals: boolean,
     eventLogger?: EventLogger
 ): Promise<AnalyzedFile> {
     const sourceFileEnvironment = await createSourceFileEnvironment(
@@ -82,7 +82,7 @@ export async function createSourceFileEnvironment(
     fileUri: Uri,
     client: CoqLspClient,
     abortSignal: AbortSignal,
-    needsTheoremInitialGoals: boolean = true,
+    needsTheoremInitialGoals: boolean,
     eventLogger?: EventLogger
 ): Promise<SourceFileEnvironment> {
     const fileTheorems = await parseCoqFile(

--- a/src/llm/llmServices/grazie/grazieService.ts
+++ b/src/llm/llmServices/grazie/grazieService.ts
@@ -120,7 +120,11 @@ class GrazieServiceInternal extends LLMServiceInternal<
         chat: ChatHistory,
         modelParams: GrazieModelParams
     ): GrazieFormattedHistory {
-        const o1CompatibleChatHistory = toO1CompatibleChatHistory(chat, modelParams.modelName);
+        const o1CompatibleChatHistory = toO1CompatibleChatHistory(
+            chat,
+            modelParams.modelName,
+            "grazie"
+        );
 
         return o1CompatibleChatHistory.map((message: ChatMessage) => {
             const grazieRoleName =

--- a/src/llm/llmServices/openai/openAiService.ts
+++ b/src/llm/llmServices/openai/openAiService.ts
@@ -14,9 +14,9 @@ import { GeneratedProofImpl } from "../generatedProof";
 import { LLMServiceImpl } from "../llmService";
 import { LLMServiceInternal } from "../llmServiceInternal";
 import { OpenAiModelParams } from "../modelParams";
+import { toO1CompatibleChatHistory } from "../utils/o1ClassModels";
 
 import { OpenAiModelParamsResolver } from "./openAiModelParamsResolver";
-import { toO1CompatibleChatHistory } from "../utils/o1ClassModels";
 
 export class OpenAiService extends LLMServiceImpl<
     OpenAiUserModelParams,
@@ -219,9 +219,9 @@ class OpenAiServiceInternal extends LLMServiceInternal<
     private static readonly connectionErrorPattern = /^Connection error\.$/;
 
     private formatChatHistory(
-        chat: ChatHistory, 
+        chat: ChatHistory,
         modelParams: OpenAiModelParams
     ): ChatHistory {
-        return toO1CompatibleChatHistory(chat, modelParams.modelName);
+        return toO1CompatibleChatHistory(chat, modelParams.modelName, "openai");
     }
 }

--- a/src/llm/llmServices/utils/o1ClassModels.ts
+++ b/src/llm/llmServices/utils/o1ClassModels.ts
@@ -1,17 +1,26 @@
 import { ChatHistory, ChatMessage } from "../commonStructures/chat";
 
-const o1ClassModels = ['o1-preview', 'o1-preview-2024-09-12', 'o1-mini', 'o1-mini-2024-09-12'];
+const o1ClassModelsOpenAI = [
+    "o1-preview",
+    "o1-preview-2024-09-12",
+    "o1-mini",
+    "o1-mini-2024-09-12",
+];
+const o1ClassModelsGrazie = ["openai-o1", "openai-o1-mini"];
 
 /**
  * As of November 2024, o1 model requires a different format of chat history.
  * It doesn't support the system prompt, therefore we manually
- * change system prompt to a user's message in case of this specific 
+ * change system prompt to a user's message in case of this specific
  * model usage.
  */
 export function toO1CompatibleChatHistory(
-    chatHistory: ChatHistory, 
-    modelName: string
+    chatHistory: ChatHistory,
+    modelName: string,
+    service: "openai" | "grazie"
 ): ChatHistory {
+    const o1ClassModels =
+        service === "openai" ? o1ClassModelsOpenAI : o1ClassModelsGrazie;
     if (o1ClassModels.includes(modelName)) {
         return chatHistory.map((message: ChatMessage) => {
             return {

--- a/src/test/commonTestFunctions/prepareEnvironment.ts
+++ b/src/test/commonTestFunctions/prepareEnvironment.ts
@@ -46,7 +46,8 @@ export async function withPreparedEnvironment<T>(
                     (_hole) => true,
                     fileUri,
                     client,
-                    new AbortController().signal
+                    new AbortController().signal,
+                    true // to support any ranker
                 )
             );
         const preparedEnvironment = {

--- a/src/test/legacyBenchmark/benchmarkingFramework.ts
+++ b/src/test/legacyBenchmark/benchmarkingFramework.ts
@@ -40,6 +40,7 @@ import { consoleLog, consoleLogSeparatorLine } from "./utils/loggingUtils";
 
 export interface TestBenchmarkOptions extends TestBenchmarkOptionsWithDefaults {
     filePath: string;
+    // TODO: support ranker
     inputModelsParams: InputModelsParams;
     relativePathToFile: string;
 }
@@ -451,7 +452,8 @@ async function prepareForBenchmarkCompletions(
             mockDocumentVersion,
             shouldCompleteHole,
             fileUri,
-            coqLspClient
+            coqLspClient,
+            true // TODO: pass `ranker.needsUnwrappedNotations` here
         );
     const llmServices: LLMServices = {
         openAiService: new OpenAiService(eventLogger),
@@ -479,14 +481,16 @@ async function extractCompletionTargets(
     documentVersion: number,
     shouldCompleteHole: (hole: ProofStep) => boolean,
     fileUri: Uri,
-    client: CoqLspClient
+    client: CoqLspClient,
+    rankerNeedsUnwrappedNotations: boolean
 ): Promise<[BenchmarkingCompletionTargets, SourceFileEnvironment]> {
     const abortController = new AbortController();
     const sourceFileEnvironment = await createSourceFileEnvironment(
         documentVersion,
         fileUri,
         client,
-        abortController.signal
+        abortController.signal,
+        rankerNeedsUnwrappedNotations
     );
     const completionTargets = await createCompletionTargets(
         documentVersion,


### PR DESCRIPTION
The key fix is to support nullable `initial_goal` inside benchmarks properly.