### PR TITLE
Release v2.4.2+0.2.2+8.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.2
+
+- Fix premise selection bug in benchmarks: in `v2.4.1`, a theorem for which the completion was issued was accidentally added to the list of premises. This was fixed in this release.
+We encountered difficulty setting the correct `coq-lsp` path in the settings, both for the `coq-lsp` plugin itself and for `coqpilot`. When using the `nix` environment, it is common for the path to be updated by hand, and it is not always done correctly. Therefore, we added a warning message to the user, which is shown when `coqpilot` suspects that the build of `coq-lsp` on the given path is not the expected one.
+
 ## 2.4.1
 
 Hot fix with update of dependencies to fix the issue on extension activation.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CoqPilot ![Version](https://img.shields.io/badge/version-v2.4.1-blue?style=flat-square)
+# CoqPilot ![Version](https://img.shields.io/badge/version-v2.4.2-blue?style=flat-square)
 
 *Authors:* Andrei Kozyrev, Gleb Solovev, Nikita Khramov, and Anton Podkopaev, [Programming Languages and Tools Lab](https://lp.jetbrains.com/research/plt_lab/) at JetBrains Research.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coqpilot",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coqpilot",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/JetBrains-Research/coqpilot"
   },
   "publisher": "JetBrains-Research",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/benchmark/framework/benchmarkingCore/executeBenchmarkingTask.ts
+++ b/src/benchmark/framework/benchmarkingCore/executeBenchmarkingTask.ts
@@ -51,6 +51,7 @@ export async function executeBenchmarkingTask(
     try {
         const generationArgs = {
             completionContext: task.getCompletionContext(),
+            sourceTheorem: task.sourceTheorem,
             sourceFileEnvironment: task.getSourceFileEnvironment(),
             benchmarkingModelParams: params,
             llmService: llmService,

--- a/src/benchmark/framework/experiment/abstractExperiment.ts
+++ b/src/benchmark/framework/experiment/abstractExperiment.ts
@@ -108,6 +108,7 @@ export abstract class AbstractExperiment {
         );
     }
 
+    // TODO: support absolute `artifactsDirPath`
     /**
      * The core method that executes the benchmarking experiment.
      *
@@ -280,9 +281,20 @@ export abstract class AbstractExperiment {
         optionsAfterStartupResolution: ExperimentRunOptions.AfterStartupResolution,
         requestedWorkspaces: string[]
     ): ExperimentRunOptions {
+        // So far `coqLspServerPath` is applied to the benchmarking system
+        // by storing it into `process.env.COQ_LSP_PATH`.
+        // TODO: pass it through the system explicitly (!)
+        const customCoqLspServerPath =
+            optionsAfterStartupResolution.coqLspServerPath;
+        if (customCoqLspServerPath !== undefined) {
+            process.env.COQ_LSP_PATH = customCoqLspServerPath;
+        }
+
         return {
             loggerSeverity: optionsAfterStartupResolution.loggerSeverity,
             logsFilePath: optionsAfterStartupResolution.logsFilePath,
+
+            coqLspServerPath: undefined, // TODO: is passed through `process.env.COQ_LSP_PATH` above
 
             datasetCacheUsage: optionsAfterStartupResolution.datasetCacheUsage,
             datasetCacheDirectoryPath:

--- a/src/benchmark/framework/structures/inputParameters/experimentRunOptions.ts
+++ b/src/benchmark/framework/structures/inputParameters/experimentRunOptions.ts
@@ -11,6 +11,17 @@ export interface ExperimentRunOptions extends BenchmarkingOptions {
      */
     logsFilePath: string | undefined;
 
+    /**
+     * Path to the coq-lsp server. Currently, it **must be set up properly**;
+     * otherwise, proof checking always suceeds even for the invalid proofs.
+     *
+     * Notes on the coq-lsp server path resolution.
+     * - If `coqLspServerPath` is set, it will be used.
+     * - Otherwise, the one stored in the `COQ_LSP_PATH` environment variable will be selected.
+     * - Finally, if none of them are set, coq-lsp will search for the server path automatically.
+     */
+    coqLspServerPath: string | undefined;
+
     datasetCacheUsage: DatasetCacheUsageMode;
     /**
      * Path relative to the root directory. If it is not set, a `dataset/.parsingCache` will be used.

--- a/src/core/coqProofChecker.ts
+++ b/src/core/coqProofChecker.ts
@@ -4,6 +4,7 @@ import { Position } from "vscode-languageclient";
 import { CoqLspClient } from "../coqLsp/coqLspClient";
 import { CoqLspTimeoutError } from "../coqLsp/coqLspTypes";
 
+import { EventLogger } from "../logging/eventLogger";
 import { Uri } from "../utils/uri";
 
 export interface ProofCheckResult {
@@ -17,7 +18,10 @@ type Proof = string;
 export class CoqProofChecker {
     private mutex: Mutex = new Mutex();
 
-    constructor(private coqLspClient: CoqLspClient) {}
+    constructor(
+        private coqLspClient: CoqLspClient,
+        private eventLogger?: EventLogger
+    ) {}
 
     async checkProofs(
         fileUri: Uri,
@@ -78,6 +82,13 @@ export class CoqProofChecker {
                 documentVersion,
                 proof
             );
+
+            if (goalsResult.err) {
+                this.eventLogger?.log(
+                    "new-proof-check",
+                    `Checking proog: ${proof}, goalsResult: ${goalsResult.val.message}`
+                );
+            }
 
             results.push({
                 proof: proof,

--- a/src/extension/coqPilot.ts
+++ b/src/extension/coqPilot.ts
@@ -72,9 +72,7 @@ export class CoqPilot {
             this.performCompletionForAllAdmits.bind(this)
         );
 
-        // TODO: would it be clearer and safer to initialise a new session
-        // instead of restarting the same object (?)
-        this.registerEditorCommand(
+        this.registerCommand(
             toggleCommand,
             this.sessionState.toggleCurrentSession.bind(this.sessionState)
         );
@@ -308,7 +306,8 @@ export class CoqPilot {
         const contextTheoremsRanker = buildTheoremsRankerFromConfig();
 
         const coqProofChecker = new CoqProofChecker(
-            this.sessionState.coqLspClient
+            this.sessionState.coqLspClient,
+            this.pluginContext.eventLogger
         );
         // Note: here and later the target file is expected to be opened by the user,
         // so no explicit `coqLspClient.openTextDocument(...)` call is needed
@@ -333,6 +332,11 @@ export class CoqPilot {
         };
 
         return [completionContexts, sourceFileEnvironment, processEnvironment];
+    }
+
+    private registerCommand(command: string, fn: () => void) {
+        let disposable = commands.registerCommand(`${pluginId}.` + command, fn);
+        this.vscodeContext.subscriptions.push(disposable);
     }
 
     private registerEditorCommand(

--- a/src/extension/ui/messages/editorMessages.ts
+++ b/src/extension/ui/messages/editorMessages.ts
@@ -36,6 +36,12 @@ export namespace EditorMessages {
     export const extensionIsPaused =
         "You have stopped CoqPilot. To resume, click on the CoqPilot icon in the status bar.";
 
+    export const wrongCoqLspSuspected = (
+        coqLspPath: string,
+        errorMessage: string
+    ): string =>
+        `CoqPilot suspects that the Coq-LSP server located at ${coqLspPath} is not working as expected, error received from server: \"${errorMessage}\". Please make sure that the server is properly installed and the path to it is set correctly in the settings.`;
+
     export const objectWasThrownAsError = (e: any) =>
         reportUnexpectedError(
             `object was thrown as error, ${stringifyAnyValue(e)}`

--- a/src/test/benchmark/singleWorkspaceSetup.test.ts
+++ b/src/test/benchmark/singleWorkspaceSetup.test.ts
@@ -35,6 +35,9 @@ suite("[SourceExecutable] Single Workspace Benchmark", () => {
         experiment.updateRunOptions({
             loggerSeverity: SeverityLevel.DEBUG,
             // logsFilePath: "benchmarkLogs/logs.txt",
+
+            // Don't forget to set up properly (or via `COQ_LSP_PATH`)
+            coqLspServerPath: "coq-lsp",
         });
 
         try {

--- a/src/test/benchmarkTest/regression.test.ts
+++ b/src/test/benchmarkTest/regression.test.ts
@@ -1,0 +1,62 @@
+import { expect } from "earl";
+import * as tmp from "tmp";
+
+import { BenchmarkingBundle } from "../../benchmark/framework/experiment/setupDSL/benchmarkingBundleBuilder";
+import { TargetsBuilder } from "../../benchmark/framework/experiment/setupDSL/targetsBuilder";
+import { SingleWorkspaceExperiment } from "../../benchmark/framework/experiment/singleWorkspaceExperiment";
+import { SeverityLevel } from "../../benchmark/framework/logging/benchmarkingLogger";
+import { colorize } from "../../benchmark/framework/logging/colorLogging";
+import { DatasetCacheUsageMode } from "../../benchmark/framework/structures/inputParameters/datasetCaching";
+import { relativizeAbsolutePaths } from "../../benchmark/framework/utils/fileUtils/fs";
+import { time, timeToMillis } from "../../utils/time";
+import { getRootDir } from "../commonTestFunctions/pathsResolver";
+
+suite("Benchmarking framework: regression tests", () => {
+    // TODO: ideally, some special testing workspace
+    // should be used instead of standalone files root
+
+    test("Smoke test: fill standalone file with `auto`", async () => {
+        const experiment = new SingleWorkspaceExperiment();
+
+        new BenchmarkingBundle()
+            .withLLMService("predefined")
+            .withBenchmarkingModelsParamsCommons({
+                ranker: "random",
+            })
+            .withBenchmarkingModelsParams({
+                modelId: "prove-with-auto",
+                tactics: ["auto."],
+            })
+            .withTargets(
+                new TargetsBuilder()
+                    .withStandaloneFilesRoot()
+                    .withAdmitTargetsFromFile("auto_benchmark.v", "test")
+                    .buildInputTargets()
+            )
+            .addTo(experiment);
+
+        const tmpDirectoryPath = tmp.dirSync().name;
+        const relativeTmpDir = relativizeAbsolutePaths(
+            getRootDir(),
+            tmpDirectoryPath
+        );
+
+        let hasSuccessfullyFinished = false;
+        try {
+            await experiment.run(relativeTmpDir, {
+                loggerSeverity: SeverityLevel.ERROR,
+                datasetCacheUsage: DatasetCacheUsageMode.NO_CACHE_USAGE,
+            });
+            hasSuccessfullyFinished = true;
+        } catch (error) {
+            console.error(
+                colorize(`\nExperiment pipeline has failed: ${error}\n`, "red")
+            );
+        }
+        expect(hasSuccessfullyFinished).toBeTruthy();
+    }).timeout(timeToMillis(time(10, "minute")));
+
+    test("Context theorems must not contain the target one", async () => {
+        // TODO
+    });
+});


### PR DESCRIPTION
- Fix premise selection bug in benchmarks: in `v2.4.1`, a theorem for which the completion was issued was accidentally added to the list of premises. This was fixed in this release.
- We encountered difficulty setting the correct `coq-lsp` path in the settings, both for the `coq-lsp` plugin itself and for `coqpilot`. When using the `nix` environment, it is common for the path to be updated by hand, and it is not always done correctly. Therefore, we added a warning message to the user, which is shown when `coqpilot` suspects that the build of `coq-lsp` on the given path is not the expected one.