### PR TITLE
Support DeepSeek in benchmarks and plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
                 },
                 "temperature": {
                   "type": "number",
-                  "description": "Temperature of the OpenAI model.",
+                  "description": "Temperature of the OpenAI model. Should be in range [0, 2], otherwise an error will be produced.",
                   "default": 1
                 },
                 "apiKey": {
@@ -306,7 +306,7 @@
                 },
                 "temperature": {
                   "type": "number",
-                  "description": "Temperature of the LM Studio model.",
+                  "description": "Temperature of the LM Studio model. Should be in range [0, 2], otherwise an error will be produced.",
                   "default": 1
                 },
                 "port": {
@@ -393,7 +393,7 @@
                 },
                 "temperature": {
                   "type": "number",
-                  "description": "Temperature of the DeepSeek model.",
+                  "description": "Temperature of the DeepSeek model. Should be in range [0, 2], otherwise an error will be produced.",
                   "default": 1
                 },
                 "apiKey": {
@@ -423,7 +423,7 @@
                 },
                 "maxContextTheoremsNumber": {
                   "type": "number",
-                  "description": "Maximum number of context theorems to include in the prompt sent to the OpenAI model as examples for proof generation. Lower values reduce token usage but may decrease the likelihood of generating correct proofs.",
+                  "description": "Maximum number of context theorems to include in the prompt sent to the DeepSeek model as examples for proof generation. Lower values reduce token usage but may decrease the likelihood of generating correct proofs.",
                   "default": 100
                 },
                 "multiroundProfile": {
@@ -459,25 +459,7 @@
                 }
               }
             },
-            "default": [
-              {
-                "modelId": "deep-seek-v3",
-                "modelName": "deepseek-chat",
-                "temperature": 1,
-                "apiKey": "None",
-                "choices": 15,
-                "systemPrompt": "Generate proof of the theorem from user input in Coq. You should only generate proofs in Coq. Never add special comments to the proof. Your answer should be a valid Coq proof. It should start with 'Proof.' and end with 'Qed.'.",
-                "maxTokensToGenerate": 2048,
-                "tokensLimit": 4096,
-                "maxContextTheoremsNumber": 100,
-                "multiroundProfile": {
-                  "maxRoundsNumber": 1,
-                  "proofFixChoices": 1,
-                  "proofFixPrompt": "Unfortunately, the last proof is not correct. Here is the compiler's feedback: '${diagnostic}'. Please, fix the proof.",
-                  "maxPreviousProofVersionsNumber": 100
-                }
-              }
-            ],
+            "default": [],
             "markdownDescription": "List of configurations for DeepSeek models. Each configuration will be fetched for completions independently in the order they are listed.",
             "order": 4
           },

--- a/package.json
+++ b/package.json
@@ -376,6 +376,111 @@
             "markdownDescription": "List of configurations that fetch completions from a locally running LLM inside [LM Studio](https://lmstudio.ai).",
             "order": 3
           },
+          "coqpilot.deepSeekModelsParameters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "modelId": {
+                  "type": "string",
+                  "markdownDescription": "Unique identifier of this model to distinguish it from others. Could be any string.",
+                  "default": "deep-seek-v3"
+                },
+                "modelName": {
+                  "type": "string",
+                  "markdownDescription": "Model to use from the DeepSeek public API. List of models known to CoqPilot: \n * deepseek-chat \n * deepseek-reasoner",
+                  "default": "deepseek-chat"
+                },
+                "temperature": {
+                  "type": "number",
+                  "description": "Temperature of the DeepSeek model.",
+                  "default": 1
+                },
+                "apiKey": {
+                  "type": "string",
+                  "description": "Api key to communicate with the DeepSeek api. You can get one [here](https://platform.deepseek.com/api_keys).",
+                  "default": "None"
+                },
+                "choices": {
+                  "type": "number",
+                  "description": "Number of attempts to generate proof for one hole with this model. All attempts are made as a single request, so this parameter should not have a significant impact on performance. However, more choices mean more tokens spent on generation.",
+                  "default": 15
+                },
+                "systemPrompt": {
+                  "type": "string",
+                  "description": "Prompt for the DeepSeek model to begin a chat with. It is sent as a system message, which means it has more impact than other messages.",
+                  "default": "Generate proof of the theorem from user input in Coq. You should only generate proofs in Coq. Never add special comments to the proof. Your answer should be a valid Coq proof. It should start with 'Proof.' and end with 'Qed.'."
+                },
+                "maxTokensToGenerate": {
+                  "type": "number",
+                  "description": "Number of tokens that the model is allowed to generate as a response message (i.e. message with proof).",
+                  "default": 2048
+                },
+                "tokensLimit": {
+                  "type": "number",
+                  "description": "Total length of input and generated tokens, it is determined by the model.",
+                  "default": 4096
+                },
+                "maxContextTheoremsNumber": {
+                  "type": "number",
+                  "description": "Maximum number of context theorems to include in the prompt sent to the OpenAI model as examples for proof generation. Lower values reduce token usage but may decrease the likelihood of generating correct proofs.",
+                  "default": 100
+                },
+                "multiroundProfile": {
+                  "type": "object",
+                  "properties": {
+                    "maxRoundsNumber": {
+                      "type": "number",
+                      "description": "Maximum number of rounds to generate and further fix the proof. Default value is 1, which means each proof will be only generated, but not fixed.",
+                      "default": 1
+                    },
+                    "proofFixChoices": {
+                      "type": "number",
+                      "description": "Number of attempts to generate a proof fix for each proof in one round. Warning: increasing `proofFixChoices` can lead to exponential growth in generation requests if `maxRoundsNumber` is relatively large.",
+                      "default": 1
+                    },
+                    "proofFixPrompt": {
+                      "type": "string",
+                      "description": "Prompt for the proof-fix request that will be sent as a user chat message in response to an incorrect proof. It may include the `${diagnostic}` substring, which will be replaced by the actual compiler diagnostic.",
+                      "default": "Unfortunately, the last proof is not correct. Here is the compiler's feedback: `${diagnostic}`. Please, fix the proof."
+                    },
+                    "maxPreviousProofVersionsNumber": {
+                      "type": "number",
+                      "description": "Maximum number of previous proof versions to include in the proof-fix chat, each presented as a dialogue: the user's diagnostic followed by the assistant's corresponding proof attempt. The most recent proof version being fixed is always included and is not affected by this parameter.",
+                      "default": 100
+                    }
+                  },
+                  "default": {
+                    "maxRoundsNumber": 1,
+                    "proofFixChoices": 1,
+                    "proofFixPrompt": "Unfortunately, the last proof is not correct. Here is the compiler's feedback: `${diagnostic}`. Please, fix the proof.",
+                    "maxPreviousProofVersionsNumber": 100
+                  }
+                }
+              }
+            },
+            "default": [
+              {
+                "modelId": "deep-seek-v3",
+                "modelName": "deepseek-chat",
+                "temperature": 1,
+                "apiKey": "None",
+                "choices": 15,
+                "systemPrompt": "Generate proof of the theorem from user input in Coq. You should only generate proofs in Coq. Never add special comments to the proof. Your answer should be a valid Coq proof. It should start with 'Proof.' and end with 'Qed.'.",
+                "maxTokensToGenerate": 2048,
+                "tokensLimit": 4096,
+                "maxContextTheoremsNumber": 100,
+                "multiroundProfile": {
+                  "maxRoundsNumber": 1,
+                  "proofFixChoices": 1,
+                  "proofFixPrompt": "Unfortunately, the last proof is not correct. Here is the compiler's feedback: '${diagnostic}'. Please, fix the proof.",
+                  "maxPreviousProofVersionsNumber": 100
+                }
+              }
+            ],
+            "markdownDescription": "List of configurations for DeepSeek models. Each configuration will be fetched for completions independently in the order they are listed.",
+            "order": 4
+          },
           "coqpilot.contextTheoremsRankerType": {
             "type": "string",
             "enum": [
@@ -390,7 +495,7 @@
             ],
             "description": "Context of the LLM is limited. Usually not all theorems from the file may be used in the completion request. This parameter defines the way theorems are selected for the completion.",
             "default": "distance",
-            "order": 4
+            "order": 5
           },
           "coqpilot.loggingVerbosity": {
             "type": "string",
@@ -404,13 +509,13 @@
             ],
             "description": "The verbosity of the logs.",
             "default": "info",
-            "order": 5
+            "order": 6
           },
           "coqpilot.coqLspServerPath": {
             "type": "string",
             "description": "Path to the Coq LSP server. If not specified, CoqPilot will try to find the server automatically at the default location: coq-lsp at PATH.",
             "default": "coq-lsp",
-            "order": 6
+            "order": 7
           }
         }
       }

--- a/src/benchmark/framework/experiment/setupDSL/benchmarkingBundleBuilder.ts
+++ b/src/benchmark/framework/experiment/setupDSL/benchmarkingBundleBuilder.ts
@@ -21,9 +21,9 @@ export type CorrespondingInputParams<T extends LLMServiceStringIdentifier> =
           : T extends "grazie"
             ? InputBenchmarkingModelParams.GrazieParams
             : T extends "lmstudio"
-              ? InputBenchmarkingModelParams.DeepSeekParams
+              ? InputBenchmarkingModelParams.LMStudioParams
               : T extends "deepseek"
-                ? InputBenchmarkingModelParams.LMStudioParams
+                ? InputBenchmarkingModelParams.DeepSeekParams
                 : never;
 
 export class BenchmarkingBundle {

--- a/src/benchmark/framework/experiment/setupDSL/benchmarkingBundleBuilder.ts
+++ b/src/benchmark/framework/experiment/setupDSL/benchmarkingBundleBuilder.ts
@@ -10,7 +10,8 @@ export type LLMServiceStringIdentifier =
     | "predefined"
     | "openai"
     | "grazie"
-    | "lmstudio";
+    | "lmstudio"
+    | "deepseek";
 
 export type CorrespondingInputParams<T extends LLMServiceStringIdentifier> =
     T extends "predefined"
@@ -20,8 +21,10 @@ export type CorrespondingInputParams<T extends LLMServiceStringIdentifier> =
           : T extends "grazie"
             ? InputBenchmarkingModelParams.GrazieParams
             : T extends "lmstudio"
-              ? InputBenchmarkingModelParams.LMStudioParams
-              : never;
+              ? InputBenchmarkingModelParams.DeepSeekParams
+              : T extends "deepseek"
+                ? InputBenchmarkingModelParams.LMStudioParams
+                : never;
 
 export class BenchmarkingBundle {
     constructor() {}
@@ -46,6 +49,8 @@ export class BenchmarkingBundle {
                 return LLMServiceIdentifier.GRAZIE;
             case "lmstudio":
                 return LLMServiceIdentifier.LMSTUDIO;
+            case "deepseek":
+                return LLMServiceIdentifier.DEEPSEEK;
         }
     }
 }

--- a/src/benchmark/framework/structures/common/llmServiceIdentifier.ts
+++ b/src/benchmark/framework/structures/common/llmServiceIdentifier.ts
@@ -3,4 +3,5 @@ export enum LLMServiceIdentifier {
     OPENAI = "Open AI",
     GRAZIE = "Grazie",
     LMSTUDIO = "LM Studio",
+    DEEPSEEK = "DeepSeek",
 }

--- a/src/benchmark/framework/structures/inputParameters/inputBenchmarkingModelParams.ts
+++ b/src/benchmark/framework/structures/inputParameters/inputBenchmarkingModelParams.ts
@@ -1,4 +1,5 @@
 import {
+    DeepSeekUserModelParams,
     GrazieUserModelParams,
     LMStudioUserModelParams,
     OpenAiUserModelParams,
@@ -22,4 +23,6 @@ export namespace InputBenchmarkingModelParams {
     export interface GrazieParams extends GrazieUserModelParams, Params {}
 
     export interface LMStudioParams extends LMStudioUserModelParams, Params {}
+
+    export interface DeepSeekParams extends DeepSeekUserModelParams, Params {}
 }

--- a/src/benchmark/framework/utils/commonStructuresUtils/llmServicesUtils.ts
+++ b/src/benchmark/framework/utils/commonStructuresUtils/llmServicesUtils.ts
@@ -1,4 +1,6 @@
 import { ErrorsHandlingMode } from "../../../../llm/llmServices/commonStructures/errorsHandlingMode";
+import { DeepSeekModelParamsResolver } from "../../../../llm/llmServices/deepSeek/deepSeekModelParamsResolver";
+import { DeepSeekService } from "../../../../llm/llmServices/deepSeek/deepSeekService";
 import { GrazieModelParamsResolver } from "../../../../llm/llmServices/grazie/grazieModelParamsResolver";
 import { GrazieService } from "../../../../llm/llmServices/grazie/grazieService";
 import { LLMService } from "../../../../llm/llmServices/llmService";
@@ -29,6 +31,8 @@ export function getShortName(identifier: LLMServiceIdentifier): string {
             return "Grazie";
         case LLMServiceIdentifier.LMSTUDIO:
             return "LM Studio";
+        case LLMServiceIdentifier.DEEPSEEK:
+            return "DeepSeek";
     }
 }
 
@@ -53,6 +57,9 @@ export function selectLLMServiceBuilder(
         case LLMServiceIdentifier.LMSTUDIO:
             return (eventLogger, errorsHandlingMode) =>
                 new LMStudioService(eventLogger, errorsHandlingMode);
+        case LLMServiceIdentifier.DEEPSEEK:
+            return (eventLogger, errorsHandlingMode) =>
+                new DeepSeekService(eventLogger, errorsHandlingMode);
     }
 }
 
@@ -61,6 +68,7 @@ export interface LLMServicesParamsResolvers {
     openAiModelParamsResolver: OpenAiModelParamsResolver;
     grazieModelParamsResolver: GrazieModelParamsResolver;
     lmStudioModelParamsResolver: LMStudioModelParamsResolver;
+    deepSeekModelParamsResolver: DeepSeekModelParamsResolver;
 }
 
 export function createParamsResolvers(): LLMServicesParamsResolvers {
@@ -70,6 +78,7 @@ export function createParamsResolvers(): LLMServicesParamsResolvers {
         openAiModelParamsResolver: new OpenAiModelParamsResolver(),
         grazieModelParamsResolver: new GrazieModelParamsResolver(),
         lmStudioModelParamsResolver: new LMStudioModelParamsResolver(),
+        deepSeekModelParamsResolver: new DeepSeekModelParamsResolver(),
     };
 }
 
@@ -86,5 +95,7 @@ export function getParamsResolver(
             return paramsResolvers.grazieModelParamsResolver;
         case LLMServiceIdentifier.LMSTUDIO:
             return paramsResolvers.lmStudioModelParamsResolver;
+        case LLMServiceIdentifier.DEEPSEEK:
+            return paramsResolvers.deepSeekModelParamsResolver;
     }
 }

--- a/src/extension/pluginContext.ts
+++ b/src/extension/pluginContext.ts
@@ -15,6 +15,7 @@ import { illegalState } from "../utils/throwErrors";
 
 import VSCodeLogWriter from "./ui/vscodeLogWriter";
 import { pluginId } from "./utils/pluginId";
+import { DeepSeekService } from "../llm/llmServices/deepSeek/deepSeekService";
 
 export class PluginContext implements Disposable {
     readonly eventLogger: EventLogger = new EventLogger();
@@ -67,6 +68,12 @@ export class PluginContext implements Disposable {
             path.join(this.llmServicesLogsDir, "lmstudio-logs.txt"),
             this.llmServicesSetup.debugLogs
         ),
+        deepSeekService: new DeepSeekService(
+            this.llmServicesSetup.eventLogger,
+            this.llmServicesSetup.errorsHandlingMode,
+            path.join(this.llmServicesLogsDir, "deepseek-logs.txt"),
+            this.llmServicesSetup.debugLogs
+        )
     };
 
     private parseLoggingVerbosity(config: WorkspaceConfiguration): Severity {

--- a/src/extension/pluginContext.ts
+++ b/src/extension/pluginContext.ts
@@ -5,6 +5,7 @@ import { Disposable, WorkspaceConfiguration, window, workspace } from "vscode";
 
 import { LLMServices, disposeServices } from "../llm/llmServices";
 import { ErrorsHandlingMode } from "../llm/llmServices/commonStructures/errorsHandlingMode";
+import { DeepSeekService } from "../llm/llmServices/deepSeek/deepSeekService";
 import { GrazieService } from "../llm/llmServices/grazie/grazieService";
 import { LMStudioService } from "../llm/llmServices/lmStudio/lmStudioService";
 import { OpenAiService } from "../llm/llmServices/openai/openAiService";
@@ -15,7 +16,6 @@ import { illegalState } from "../utils/throwErrors";
 
 import VSCodeLogWriter from "./ui/vscodeLogWriter";
 import { pluginId } from "./utils/pluginId";
-import { DeepSeekService } from "../llm/llmServices/deepSeek/deepSeekService";
 
 export class PluginContext implements Disposable {
     readonly eventLogger: EventLogger = new EventLogger();
@@ -73,7 +73,7 @@ export class PluginContext implements Disposable {
             this.llmServicesSetup.errorsHandlingMode,
             path.join(this.llmServicesLogsDir, "deepseek-logs.txt"),
             this.llmServicesSetup.debugLogs
-        )
+        ),
     };
 
     private parseLoggingVerbosity(config: WorkspaceConfiguration): Severity {

--- a/src/extension/settings/configReaders.ts
+++ b/src/extension/settings/configReaders.ts
@@ -126,7 +126,7 @@ export function readAndValidateUserModelsParams(
         ...lmStudioUserParams,
         ...deepSeekUserParams,
     ]);
-    validateApiKeysAreProvided(openAiUserParams, grazieUserParams);
+    validateApiKeysAreProvided(openAiUserParams, grazieUserParams, deepSeekUserParams);
 
     const modelsParams: ModelsParams = {
         predefinedProofsModelParams: resolveParamsAndShowResolutionLogs(
@@ -213,7 +213,8 @@ function validateIdsAreUnique(allModels: UserModelParams[]) {
 
 function validateApiKeysAreProvided(
     openAiUserParams: OpenAiUserModelParams[],
-    grazieUserParams: GrazieUserModelParams[]
+    grazieUserParams: GrazieUserModelParams[],
+    deepSeekUserParams: DeepSeekUserModelParams[]
 ) {
     const buildApiKeyError = (
         serviceName: string,
@@ -232,6 +233,9 @@ function validateApiKeysAreProvided(
     }
     if (grazieUserParams.some((params) => params.apiKey === "None")) {
         throw buildApiKeyError("Grazie", "grazie");
+    }
+    if (deepSeekUserParams.some((params) => params.apiKey === "None")) {
+        throw buildApiKeyError("Deep Seek", "deepSeek");
     }
 }
 

--- a/src/extension/settings/configReaders.ts
+++ b/src/extension/settings/configReaders.ts
@@ -6,11 +6,13 @@ import { LLMService } from "../../llm/llmServices/llmService";
 import { ModelParams, ModelsParams } from "../../llm/llmServices/modelParams";
 import { SingleParamResolutionResult } from "../../llm/llmServices/utils/paramsResolvers/abstractResolvers";
 import {
+    DeepSeekUserModelParams,
     GrazieUserModelParams,
     LMStudioUserModelParams,
     OpenAiUserModelParams,
     PredefinedProofsUserModelParams,
     UserModelParams,
+    deepSeekUserModelParamsSchema,
     grazieUserModelParamsSchema,
     lmStudioUserModelParamsSchema,
     openAiUserModelParamsSchema,
@@ -108,12 +110,21 @@ export function readAndValidateUserModelsParams(
                 jsonSchemaValidator
             )
         );
+    const deepSeekUserParams: DeepSeekUserModelParams[] =
+        config.deepSeekModelsParameters.map((params: any) =>
+            validateAndParseJson(
+                params,
+                deepSeekUserModelParamsSchema,
+                jsonSchemaValidator
+            )
+        );
 
     validateIdsAreUnique([
         ...predefinedProofsUserParams,
         ...openAiUserParams,
         ...grazieUserParams,
         ...lmStudioUserParams,
+        ...deepSeekUserParams,
     ]);
     validateApiKeysAreProvided(openAiUserParams, grazieUserParams);
 
@@ -133,6 +144,10 @@ export function readAndValidateUserModelsParams(
         lmStudioParams: resolveParamsAndShowResolutionLogs(
             llmServices.lmStudioService,
             lmStudioUserParams
+        ),
+        deepSeekParams: resolveParamsAndShowResolutionLogs(
+            llmServices.deepSeekService,
+            deepSeekUserParams
         ),
     };
 

--- a/src/extension/settings/configReaders.ts
+++ b/src/extension/settings/configReaders.ts
@@ -126,7 +126,11 @@ export function readAndValidateUserModelsParams(
         ...lmStudioUserParams,
         ...deepSeekUserParams,
     ]);
-    validateApiKeysAreProvided(openAiUserParams, grazieUserParams, deepSeekUserParams);
+    validateApiKeysAreProvided(
+        openAiUserParams,
+        grazieUserParams,
+        deepSeekUserParams
+    );
 
     const modelsParams: ModelsParams = {
         predefinedProofsModelParams: resolveParamsAndShowResolutionLogs(

--- a/src/extension/settings/settingsValidationError.ts
+++ b/src/extension/settings/settingsValidationError.ts
@@ -34,7 +34,8 @@ export function toSettingName(llmService: LLMService<any, any>): string {
         () => "predefinedProofs",
         () => "openAi",
         () => "grazie",
-        () => "lmStudio"
+        () => "lmStudio",
+        () => "deepSeek"
     );
     return `${pluginId}.${serviceNameInSettings}ModelsParameters`;
 }

--- a/src/llm/llmIterator.ts
+++ b/src/llm/llmIterator.ts
@@ -36,6 +36,7 @@ export class LLMSequentialIterator
         );
     }
 
+    // TODO: Implement a smarter way of ordering the services
     private createHooks(
         proofGenerationContext: ProofGenerationContext,
         modelsParams: ModelsParams,
@@ -47,6 +48,16 @@ export class LLMSequentialIterator
                 modelsParams.predefinedProofsModelParams,
                 services.predefinedProofsService,
                 "predefined-proofs"
+            ),
+            // Here DeepSeek service is reordered to the beginning
+            // of the list, due to it's strong performance and
+            // low costs. Refer to discussion: 
+            // https://github.com/JetBrains-Research/coqpilot/pull/56#discussion_r1935180516
+            ...this.createLLMServiceHooks(
+                proofGenerationContext,
+                modelsParams.deepSeekParams,
+                services.deepSeekService,
+                "deepseek"
             ),
             ...this.createLLMServiceHooks(
                 proofGenerationContext,
@@ -65,12 +76,6 @@ export class LLMSequentialIterator
                 modelsParams.lmStudioParams,
                 services.lmStudioService,
                 "lm-studio"
-            ),
-            ...this.createLLMServiceHooks(
-                proofGenerationContext,
-                modelsParams.deepSeekParams,
-                services.deepSeekService,
-                "deepseek"
             ),
         ];
     }

--- a/src/llm/llmIterator.ts
+++ b/src/llm/llmIterator.ts
@@ -51,7 +51,7 @@ export class LLMSequentialIterator
             ),
             // Here DeepSeek service is reordered to the beginning
             // of the list, due to it's strong performance and
-            // low costs. Refer to discussion: 
+            // low costs. Refer to discussion:
             // https://github.com/JetBrains-Research/coqpilot/pull/56#discussion_r1935180516
             ...this.createLLMServiceHooks(
                 proofGenerationContext,

--- a/src/llm/llmIterator.ts
+++ b/src/llm/llmIterator.ts
@@ -66,6 +66,12 @@ export class LLMSequentialIterator
                 services.lmStudioService,
                 "lm-studio"
             ),
+            ...this.createLLMServiceHooks(
+                proofGenerationContext,
+                modelsParams.deepSeekParams,
+                services.deepSeekService,
+                "deepseek"
+            ),
         ];
     }
 

--- a/src/llm/llmServices.ts
+++ b/src/llm/llmServices.ts
@@ -1,6 +1,6 @@
 import { illegalState } from "../utils/throwErrors";
-import { DeepSeekService } from "./llmServices/deepSeek/deepSeekService";
 
+import { DeepSeekService } from "./llmServices/deepSeek/deepSeekService";
 import { GrazieService } from "./llmServices/grazie/grazieService";
 import { LLMService } from "./llmServices/llmService";
 import { LMStudioService } from "./llmServices/lmStudio/lmStudioService";

--- a/src/llm/llmServices.ts
+++ b/src/llm/llmServices.ts
@@ -1,4 +1,5 @@
 import { illegalState } from "../utils/throwErrors";
+import { DeepSeekService } from "./llmServices/deepSeek/deepSeekService";
 
 import { GrazieService } from "./llmServices/grazie/grazieService";
 import { LLMService } from "./llmServices/llmService";
@@ -13,6 +14,7 @@ export interface LLMServices {
     openAiService: OpenAiService;
     grazieService: GrazieService;
     lmStudioService: LMStudioService;
+    deepSeekService: DeepSeekService;
 }
 
 export function disposeServices(llmServices: LLMServices) {
@@ -27,6 +29,7 @@ export function asLLMServices(
         llmServices.openAiService,
         llmServices.grazieService,
         llmServices.lmStudioService,
+        llmServices.deepSeekService,
     ];
 }
 
@@ -35,7 +38,8 @@ export function switchByLLMServiceType<T>(
     onPredefinedProofsService: () => T,
     onOpenAiService: () => T,
     onGrazieService: () => T,
-    onLMStudioService: () => T
+    onLMStudioService: () => T,
+    onDeepSeekService: () => T
 ): T {
     if (llmService instanceof PredefinedProofsService) {
         return onPredefinedProofsService();
@@ -45,6 +49,8 @@ export function switchByLLMServiceType<T>(
         return onGrazieService();
     } else if (llmService instanceof LMStudioService) {
         return onLMStudioService();
+    } else if (llmService instanceof DeepSeekService) {
+        return onDeepSeekService();
     } else {
         illegalState(
             `switch by unknown \`LLMService\`: "${llmService.serviceName}"`

--- a/src/llm/llmServices/deepSeek/deepSeekModelParamsResolver.ts
+++ b/src/llm/llmServices/deepSeek/deepSeekModelParamsResolver.ts
@@ -1,0 +1,40 @@
+import { DeepSeekUserModelParams } from "../../userModelParams";
+import { DeepSeekModelParams, deepSeekModelParamsSchema } from "../modelParams";
+import { BasicModelParamsResolver } from "../utils/paramsResolvers/basicModelParamsResolvers";
+import { ValidParamsResolverImpl } from "../utils/paramsResolvers/paramsResolverImpl";
+
+export class DeepSeekModelParamsResolver
+    extends BasicModelParamsResolver<
+        DeepSeekUserModelParams,
+        DeepSeekModelParams
+    >
+    implements
+        ValidParamsResolverImpl<DeepSeekUserModelParams, DeepSeekModelParams>
+{
+    constructor() {
+        super(deepSeekModelParamsSchema, "DeepSeekModelParams");
+    }
+
+    readonly modelName = this.resolveParam<string>("modelName")
+        .requiredToBeConfigured()
+        .validate([
+            (value) =>
+                DeepSeekModelParamsResolver._allowedModels.includes(value),
+            `be one of the allowed models: ${DeepSeekModelParamsResolver._allowedModels.join(
+                ", "
+            )}`,
+        ]);
+
+    readonly temperature = this.resolveParam<number>("temperature")
+        .requiredToBeConfigured()
+        .validate([
+            (value) => value >= 0 && value <= 2,
+            "be in range between 0 and 2",
+        ]);
+
+    readonly apiKey = this.resolveParam<string>("apiKey")
+        .requiredToBeConfigured()
+        .validateAtRuntimeOnly();
+
+    static readonly _allowedModels = ["deepseek-chat", "deepseek-reasoner"];
+}

--- a/src/llm/llmServices/deepSeek/deepSeekModelParamsResolver.ts
+++ b/src/llm/llmServices/deepSeek/deepSeekModelParamsResolver.ts
@@ -19,8 +19,8 @@ export class DeepSeekModelParamsResolver
         .requiredToBeConfigured()
         .validate([
             (value) =>
-                DeepSeekModelParamsResolver._allowedModels.includes(value),
-            `be one of the allowed models: ${DeepSeekModelParamsResolver._allowedModels.join(
+                DeepSeekModelParamsResolver.allowedModels.includes(value),
+            `be one of the allowed models: ${DeepSeekModelParamsResolver.allowedModels.join(
                 ", "
             )}`,
         ]);
@@ -36,5 +36,5 @@ export class DeepSeekModelParamsResolver
         .requiredToBeConfigured()
         .validateAtRuntimeOnly();
 
-    static readonly _allowedModels = ["deepseek-chat", "deepseek-reasoner"];
+    static readonly allowedModels = ["deepseek-chat", "deepseek-reasoner"];
 }

--- a/src/llm/llmServices/deepSeek/deepSeekService.ts
+++ b/src/llm/llmServices/deepSeek/deepSeekService.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
 
+import { illegalState } from "../../../utils/throwErrors";
 import { ProofGenerationContext } from "../../proofGenerationContext";
 import { DeepSeekUserModelParams } from "../../userModelParams";
 import { AnalyzedChatHistory, ChatHistory } from "../commonStructures/chat";
@@ -15,7 +16,6 @@ import { DeepSeekModelParams } from "../modelParams";
 import { toO1CompatibleChatHistory } from "../utils/o1ClassModels";
 
 import { DeepSeekModelParamsResolver } from "./deepSeekModelParamsResolver";
-import { illegalState } from "../../../utils/throwErrors";
 
 export class DeepSeekService extends LLMServiceImpl<
     DeepSeekUserModelParams,
@@ -96,14 +96,15 @@ class DeepSeekServiceInternal extends LLMServiceInternal<
         });
 
         try {
-            const completion = await openaiCompatibleApi.chat.completions.create({
-                messages: formattedChat,
-                model: params.modelName,
-                n: choices,
-                temperature: params.temperature,
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                max_tokens: params.maxTokensToGenerate,
-            });
+            const completion =
+                await openaiCompatibleApi.chat.completions.create({
+                    messages: formattedChat,
+                    model: params.modelName,
+                    n: choices,
+                    temperature: params.temperature,
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    max_tokens: params.maxTokensToGenerate,
+                });
             const rawContentItems = completion.choices.map((choice) => {
                 const content = choice.message.content;
                 if (content === null) {
@@ -152,6 +153,10 @@ class DeepSeekServiceInternal extends LLMServiceInternal<
         chat: ChatHistory,
         modelParams: DeepSeekModelParams
     ): ChatHistory {
-        return toO1CompatibleChatHistory(chat, modelParams.modelName, "deepseek");
+        return toO1CompatibleChatHistory(
+            chat,
+            modelParams.modelName,
+            "deepseek"
+        );
     }
 }

--- a/src/llm/llmServices/deepSeek/deepSeekService.ts
+++ b/src/llm/llmServices/deepSeek/deepSeekService.ts
@@ -1,0 +1,157 @@
+import OpenAI from "openai";
+
+import { ProofGenerationContext } from "../../proofGenerationContext";
+import { DeepSeekUserModelParams } from "../../userModelParams";
+import { AnalyzedChatHistory, ChatHistory } from "../commonStructures/chat";
+import {
+    GeneratedRawContent,
+    GeneratedRawContentItem,
+} from "../commonStructures/generatedRawContent";
+import { ProofVersion } from "../commonStructures/proofVersion";
+import { GeneratedProofImpl } from "../generatedProof";
+import { LLMServiceImpl } from "../llmService";
+import { LLMServiceInternal } from "../llmServiceInternal";
+import { OpenAiModelParams } from "../modelParams";
+import { DeepSeekModelParams } from "../modelParams";
+import { toO1CompatibleChatHistory } from "../utils/o1ClassModels";
+
+import { DeepSeekModelParamsResolver } from "./deepSeekModelParamsResolver";
+
+export class DeepSeekService extends LLMServiceImpl<
+    DeepSeekUserModelParams,
+    DeepSeekModelParams,
+    DeepSeekService,
+    DeepSeekGeneratedProof,
+    DeepSeekServiceInternal
+> {
+    readonly serviceName = "DeepSeekService";
+    protected readonly internal = new DeepSeekServiceInternal(
+        this,
+        this.eventLogger,
+        this.generationsLoggerBuilder
+    );
+    protected readonly modelParamsResolver = new DeepSeekModelParamsResolver();
+
+    static readonly baseApiUrl = "https://api.deepseek.com/v1";
+}
+
+export class DeepSeekGeneratedProof extends GeneratedProofImpl<
+    DeepSeekModelParams,
+    DeepSeekService,
+    DeepSeekGeneratedProof,
+    DeepSeekServiceInternal
+> {
+    constructor(
+        rawProof: GeneratedRawContentItem,
+        proofGenerationContext: ProofGenerationContext,
+        modelParams: OpenAiModelParams,
+        llmServiceInternal: DeepSeekServiceInternal,
+        previousProofVersions?: ProofVersion[]
+    ) {
+        super(
+            rawProof,
+            proofGenerationContext,
+            modelParams,
+            llmServiceInternal,
+            previousProofVersions
+        );
+    }
+}
+
+class DeepSeekServiceInternal extends LLMServiceInternal<
+    DeepSeekModelParams,
+    DeepSeekService,
+    DeepSeekGeneratedProof,
+    DeepSeekServiceInternal
+> {
+    constructGeneratedProof(
+        rawProof: GeneratedRawContentItem,
+        proofGenerationContext: ProofGenerationContext,
+        modelParams: OpenAiModelParams,
+        previousProofVersions?: ProofVersion[] | undefined
+    ): DeepSeekGeneratedProof {
+        return new DeepSeekGeneratedProof(
+            rawProof,
+            proofGenerationContext,
+            modelParams,
+            this,
+            previousProofVersions
+        );
+    }
+
+    async generateFromChatImpl(
+        analyzedChat: AnalyzedChatHistory,
+        params: OpenAiModelParams,
+        choices: number
+    ): Promise<GeneratedRawContent> {
+        LLMServiceInternal.validateChoices(choices);
+
+        const openai = new OpenAI({
+            apiKey: params.apiKey,
+            baseURL: DeepSeekService.baseApiUrl,
+        });
+        const formattedChat = this.formatChatHistory(analyzedChat.chat, params);
+        this.logDebug.event("Completion requested", {
+            history: formattedChat,
+        });
+
+        try {
+            const completion = await openai.chat.completions.create({
+                messages: formattedChat,
+                model: params.modelName,
+                n: choices,
+                temperature: params.temperature,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                max_tokens: params.maxTokensToGenerate,
+            });
+            const rawContentItems = completion.choices.map((choice) => {
+                const content = choice.message.content;
+                if (content === null) {
+                    throw Error("response message content is null");
+                }
+                return content;
+            });
+
+            return this.packContentWithTokensMetrics(
+                rawContentItems,
+                completion.usage,
+                analyzedChat,
+                params
+            );
+        } catch (e) {
+            // TODO: Implement error repacking, according to the documentation
+            // https://api-docs.deepseek.com/quick_start/error_codes
+            // Postponed due to API unavailability
+            // throw DeepSeekServiceInternal.repackKnownError(e, params);
+            throw e;
+        }
+    }
+
+    private packContentWithTokensMetrics(
+        rawContentItems: string[],
+        tokensUsage: OpenAI.Completions.CompletionUsage | undefined,
+        analyzedChat: AnalyzedChatHistory,
+        params: OpenAiModelParams
+    ): GeneratedRawContent {
+        const promptTokens =
+            tokensUsage?.prompt_tokens ??
+            analyzedChat.estimatedTokens.messagesTokens;
+        return LLMServiceInternal.aggregateToGeneratedRawContent(
+            rawContentItems,
+            promptTokens,
+            params.modelName,
+            {
+                promptTokens: promptTokens,
+                generatedTokens: tokensUsage?.completion_tokens,
+                tokensSpentInTotal: tokensUsage?.total_tokens,
+            }
+        );
+    }
+
+    private formatChatHistory(
+        chat: ChatHistory,
+        modelParams: OpenAiModelParams
+    ): ChatHistory {
+        return toO1CompatibleChatHistory(chat, modelParams.modelName, "openai");
+    }
+}

--- a/src/llm/llmServices/modelParams.ts
+++ b/src/llm/llmServices/modelParams.ts
@@ -67,6 +67,7 @@ export interface ModelsParams {
     openAiParams: OpenAiModelParams[];
     grazieParams: GrazieModelParams[];
     lmStudioParams: LMStudioModelParams[];
+    deepSeekParams: DeepSeekModelParams[];
 }
 
 export const multiroundProfileSchema: JSONSchemaType<MultiroundProfile> = {

--- a/src/llm/llmServices/modelParams.ts
+++ b/src/llm/llmServices/modelParams.ts
@@ -56,6 +56,12 @@ export interface LMStudioModelParams extends ModelParams {
     port: number;
 }
 
+export interface DeepSeekModelParams extends ModelParams {
+    modelName: string;
+    temperature: number;
+    apiKey: string;
+}
+
 export interface ModelsParams {
     predefinedProofsModelParams: PredefinedProofsModelParams[];
     openAiParams: OpenAiModelParams[];
@@ -168,5 +174,23 @@ export const lmStudioModelParamsSchema: JSONSchemaType<LMStudioModelParams> = {
         ...(modelParamsSchema.properties as PropertiesSchema<ModelParams>),
     },
     required: ["temperature", "port", ...modelParamsSchema.required],
+    additionalProperties: false,
+};
+
+export const deepSeekModelParamsSchema: JSONSchemaType<DeepSeekModelParams> = {
+    title: "deepSeekModelsParameters",
+    type: "object",
+    properties: {
+        modelName: { type: "string" },
+        temperature: { type: "number" },
+        apiKey: { type: "string" },
+        ...(modelParamsSchema.properties as PropertiesSchema<ModelParams>),
+    },
+    required: [
+        "modelName",
+        "temperature",
+        "apiKey",
+        ...modelParamsSchema.required,
+    ],
     additionalProperties: false,
 };

--- a/src/llm/llmServices/utils/o1ClassModels.ts
+++ b/src/llm/llmServices/utils/o1ClassModels.ts
@@ -9,6 +9,10 @@ const o1ClassModelsOpenAI = [
 
 const o1ClassModelsGrazie = ["openai-o1", "openai-o1-mini"];
 
+// TODO: When DeepSeek API becomes stable: 
+// check whether the r1 model chat history is compatible with o1 model
+const o1ClassModelsDeepSeek = ["deepseek-reasoner"];
+
 /**
  * As of November 2024, o1 model requires a different format of chat history.
  * It doesn't support the system prompt, therefore we manually
@@ -18,10 +22,15 @@ const o1ClassModelsGrazie = ["openai-o1", "openai-o1-mini"];
 export function toO1CompatibleChatHistory(
     chatHistory: ChatHistory,
     modelName: string,
-    service: "openai" | "grazie"
+    service: "openai" | "grazie" | "deepseek"
 ): ChatHistory {
     const o1ClassModels =
-        service === "openai" ? o1ClassModelsOpenAI : o1ClassModelsGrazie;
+        service === "openai"
+            ? o1ClassModelsOpenAI
+            : service === "grazie"
+            ? o1ClassModelsGrazie
+            : o1ClassModelsDeepSeek;
+        
     if (o1ClassModels.includes(modelName)) {
         return chatHistory.map((message: ChatMessage) => {
             return {

--- a/src/llm/llmServices/utils/o1ClassModels.ts
+++ b/src/llm/llmServices/utils/o1ClassModels.ts
@@ -9,7 +9,7 @@ const o1ClassModelsOpenAI = [
 
 const o1ClassModelsGrazie = ["openai-o1", "openai-o1-mini"];
 
-// TODO: When DeepSeek API becomes stable: 
+// TODO: When DeepSeek API becomes stable:
 // check whether the r1 model chat history is compatible with o1 model
 const o1ClassModelsDeepSeek = ["deepseek-reasoner"];
 
@@ -28,9 +28,9 @@ export function toO1CompatibleChatHistory(
         service === "openai"
             ? o1ClassModelsOpenAI
             : service === "grazie"
-            ? o1ClassModelsGrazie
-            : o1ClassModelsDeepSeek;
-        
+              ? o1ClassModelsGrazie
+              : o1ClassModelsDeepSeek;
+
     if (o1ClassModels.includes(modelName)) {
         return chatHistory.map((message: ChatMessage) => {
             return {

--- a/src/llm/userModelParams.ts
+++ b/src/llm/userModelParams.ts
@@ -175,7 +175,7 @@ export const lmStudioUserModelParamsSchema: JSONSchemaType<LMStudioUserModelPara
         additionalProperties: false,
     };
 
-    export const deepSeekUserModelParamsSchema: JSONSchemaType<DeepSeekUserModelParams> =
+export const deepSeekUserModelParamsSchema: JSONSchemaType<DeepSeekUserModelParams> =
     {
         title: "deepSeekModelsParameters",
         type: "object",

--- a/src/llm/userModelParams.ts
+++ b/src/llm/userModelParams.ts
@@ -174,3 +174,17 @@ export const lmStudioUserModelParamsSchema: JSONSchemaType<LMStudioUserModelPara
         required: ["modelId", "temperature", "port"],
         additionalProperties: false,
     };
+
+    export const deepSeekUserModelParamsSchema: JSONSchemaType<DeepSeekUserModelParams> =
+    {
+        title: "deepSeekModelsParameters",
+        type: "object",
+        properties: {
+            modelName: { type: "string" },
+            temperature: { type: "number" },
+            apiKey: { type: "string" },
+            ...(userModelParamsSchema.properties as PropertiesSchema<UserModelParams>),
+        },
+        required: ["modelId", "modelName", "temperature", "apiKey"],
+        additionalProperties: false,
+    };

--- a/src/llm/userModelParams.ts
+++ b/src/llm/userModelParams.ts
@@ -78,6 +78,12 @@ export interface LMStudioUserModelParams extends UserModelParams {
     port: number;
 }
 
+export interface DeepSeekUserModelParams extends UserModelParams {
+    modelName: string;
+    temperature: number;
+    apiKey: string;
+}
+
 export const userMultiroundProfileSchema: JSONSchemaType<UserMultiroundProfile> =
     {
         type: "object",

--- a/src/test/commonTestFunctions/defaultLLMServicesBuilder.ts
+++ b/src/test/commonTestFunctions/defaultLLMServicesBuilder.ts
@@ -1,4 +1,5 @@
 import { LLMServices } from "../../llm/llmServices";
+import { DeepSeekService } from "../../llm/llmServices/deepSeek/deepSeekService";
 import { GrazieService } from "../../llm/llmServices/grazie/grazieService";
 import { LMStudioService } from "../../llm/llmServices/lmStudio/lmStudioService";
 import {
@@ -16,11 +17,13 @@ export function createDefaultServices(): LLMServices {
     const openAiService = new OpenAiService();
     const grazieService = new GrazieService();
     const lmStudioService = new LMStudioService();
+    const deepSeekService = new DeepSeekService();
     return {
         predefinedProofsService,
         openAiService,
         grazieService,
         lmStudioService,
+        deepSeekService,
     };
 }
 
@@ -32,6 +35,7 @@ export function createTrivialModelsParams(
         openAiParams: [],
         grazieParams: [],
         lmStudioParams: [],
+        deepSeekParams: [],
     };
 }
 

--- a/src/test/legacyBenchmark/benchmarkingFramework.ts
+++ b/src/test/legacyBenchmark/benchmarkingFramework.ts
@@ -39,6 +39,7 @@ import { AdditionalFileImport } from "./additionalImports";
 import { InputModelsParams } from "./inputModelsParams";
 import { BenchmarkReportHolder, TheoremProofResult } from "./reportHolder";
 import { consoleLog, consoleLogSeparatorLine } from "./utils/loggingUtils";
+import { DeepSeekService } from "../../llm/llmServices/deepSeek/deepSeekService";
 
 export interface TestBenchmarkOptions extends TestBenchmarkOptionsWithDefaults {
     filePath: string;
@@ -461,6 +462,7 @@ async function prepareForBenchmarkCompletions(
         grazieService: new GrazieService(eventLogger),
         predefinedProofsService: new PredefinedProofsService(eventLogger),
         lmStudioService: new LMStudioService(eventLogger),
+        deepSeekService: new DeepSeekService(eventLogger),
     };
     const processEnvironment: ProcessEnvironment = {
         coqProofChecker: coqProofChecker,
@@ -603,6 +605,9 @@ function resolveInputModelsParametersOrThrow(
         ),
         lmStudioParams: inputModelsParams.lmStudioParams.map((inputParams) =>
             resolveParametersOrThrow(llmServices.lmStudioService, inputParams)
+        ),
+        deepSeekParams: inputModelsParams.deepSeekParams.map((inputParams) =>
+            resolveParametersOrThrow(llmServices.deepSeekService, inputParams)
         ),
     };
 }

--- a/src/test/legacyBenchmark/benchmarkingFramework.ts
+++ b/src/test/legacyBenchmark/benchmarkingFramework.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 
 import { LLMServices } from "../../llm/llmServices";
 import { isLLMServiceRequestSucceeded } from "../../llm/llmServices/commonStructures/llmServiceRequest";
+import { DeepSeekService } from "../../llm/llmServices/deepSeek/deepSeekService";
 import { GrazieService } from "../../llm/llmServices/grazie/grazieService";
 import { LLMServiceImpl } from "../../llm/llmServices/llmService";
 import { LMStudioService } from "../../llm/llmServices/lmStudio/lmStudioService";
@@ -39,7 +40,6 @@ import { AdditionalFileImport } from "./additionalImports";
 import { InputModelsParams } from "./inputModelsParams";
 import { BenchmarkReportHolder, TheoremProofResult } from "./reportHolder";
 import { consoleLog, consoleLogSeparatorLine } from "./utils/loggingUtils";
-import { DeepSeekService } from "../../llm/llmServices/deepSeek/deepSeekService";
 
 export interface TestBenchmarkOptions extends TestBenchmarkOptionsWithDefaults {
     filePath: string;

--- a/src/test/legacyBenchmark/inputModelsParams.ts
+++ b/src/test/legacyBenchmark/inputModelsParams.ts
@@ -1,4 +1,5 @@
 import {
+    DeepSeekUserModelParams,
     GrazieUserModelParams,
     LMStudioUserModelParams,
     OpenAiUserModelParams,
@@ -10,6 +11,7 @@ export interface InputModelsParams {
     openAiParams: OpenAiUserModelParams[];
     grazieParams: GrazieUserModelParams[];
     lmStudioParams: LMStudioUserModelParams[];
+    deepSeekParams: DeepSeekUserModelParams[];
 }
 
 export const onlyAutoModelsParams: InputModelsParams = {

--- a/src/test/legacyBenchmark/inputModelsParams.ts
+++ b/src/test/legacyBenchmark/inputModelsParams.ts
@@ -24,6 +24,7 @@ export const onlyAutoModelsParams: InputModelsParams = {
         },
     ],
     lmStudioParams: [],
+    deepSeekParams: [],
 };
 
 export const tacticianModelsParams: InputModelsParams = {
@@ -36,4 +37,5 @@ export const tacticianModelsParams: InputModelsParams = {
         },
     ],
     lmStudioParams: [],
+    deepSeekParams: [],
 };

--- a/src/test/llm/llmServices/deepSeekService.test.ts
+++ b/src/test/llm/llmServices/deepSeekService.test.ts
@@ -31,6 +31,8 @@ suite("[LLMService] Test `DeepSeekService`", function () {
         modelName: deepSeekModelName,
         temperature: 1,
         choices: choices,
+        maxTokensToGenerate: 2000,
+        tokensLimit: 4000,
     };
 
     testIf(

--- a/src/test/llm/llmServices/deepSeekService.test.ts
+++ b/src/test/llm/llmServices/deepSeekService.test.ts
@@ -92,15 +92,6 @@ suite("[LLMService] Test `DeepSeekService`", function () {
                         -1
                     );
                 }).toBeRejectedWith(ConfigurationError, "choices");
-
-                // incorrect api key
-                await expect(async () => {
-                    await deepSeekService.generateProof(
-                        mockProofGenerationContext,
-                        resolvedParams,
-                        1
-                    );
-                }).toBeRejectedWith(ConfigurationError, "api key");
             }
         );
     });

--- a/src/test/llm/llmServices/deepSeekService.test.ts
+++ b/src/test/llm/llmServices/deepSeekService.test.ts
@@ -1,0 +1,151 @@
+import { expect } from "earl";
+
+import { ConfigurationError } from "../../../llm/llmServiceErrors";
+import { DeepSeekService } from "../../../llm/llmServices/deepSeek/deepSeekService";
+import { DeepSeekModelParams } from "../../../llm/llmServices/modelParams";
+import { DeepSeekUserModelParams } from "../../../llm/userModelParams";
+
+import { testIf } from "../../commonTestFunctions/conditionalTest";
+import {
+    withLLMService,
+    withLLMServiceAndParams,
+} from "../../commonTestFunctions/withLLMService";
+import {
+    deepSeekModelName,
+    mockProofGenerationContext,
+    testModelId,
+} from "../llmSpecificTestUtils/constants";
+import { testLLMServiceCompletesAdmitFromFile } from "../llmSpecificTestUtils/testAdmitCompletion";
+import {
+    paramsResolvedWithBasicDefaults,
+    testResolveValidCompleteParameters,
+} from "../llmSpecificTestUtils/testResolveParameters";
+
+suite("[LLMService] Test `DeepSeekService`", function () {
+    const apiKey = process.env.DEEPSEEK_API_KEY;
+    const choices = 15;
+    const inputFile = ["small_document.v"];
+
+    const requiredInputParamsTemplate = {
+        modelId: testModelId,
+        modelName: deepSeekModelName,
+        temperature: 1,
+        choices: choices,
+    };
+
+    testIf(
+        apiKey !== undefined,
+        "`DEEPSEEK_API_KEY` is not specified",
+        this.title,
+        `Simple generation: 1 request, ${choices} choices`,
+        async () => {
+            const inputParams: DeepSeekUserModelParams = {
+                ...requiredInputParamsTemplate,
+                apiKey: apiKey!,
+            };
+            const deepSeekService = new DeepSeekService();
+            await testLLMServiceCompletesAdmitFromFile(
+                deepSeekService,
+                inputParams,
+                inputFile,
+                choices
+            );
+        }
+    )?.timeout(5000);
+
+    test("Test `resolveParameters` reads & accepts valid params", async () => {
+        const inputParams: DeepSeekUserModelParams = {
+            ...requiredInputParamsTemplate,
+            apiKey: "undefined",
+        };
+        await withLLMService(new DeepSeekService(), async (deepSeekService) => {
+            testResolveValidCompleteParameters(deepSeekService, inputParams);
+            testResolveValidCompleteParameters(
+                deepSeekService,
+                {
+                    ...inputParams,
+                    ...paramsResolvedWithBasicDefaults,
+                    maxTokensToGenerate: 2000,
+                    tokensLimit: 4000,
+                },
+                true
+            );
+        });
+    });
+
+    test("Test `generateProof` throws on invalid configurations, <no api key needed>", async () => {
+        const inputParams: DeepSeekUserModelParams = {
+            ...requiredInputParamsTemplate,
+            apiKey: "undefined",
+        };
+        await withLLMServiceAndParams(
+            new DeepSeekService(),
+            inputParams,
+            async (deepSeekService, resolvedParams: DeepSeekModelParams) => {
+                // non-positive choices
+                await expect(async () => {
+                    await deepSeekService.generateProof(
+                        mockProofGenerationContext,
+                        resolvedParams,
+                        -1
+                    );
+                }).toBeRejectedWith(ConfigurationError, "choices");
+
+                // incorrect api key
+                await expect(async () => {
+                    await deepSeekService.generateProof(
+                        mockProofGenerationContext,
+                        resolvedParams,
+                        1
+                    );
+                }).toBeRejectedWith(ConfigurationError, "api key");
+            }
+        );
+    });
+
+    testIf(
+        apiKey !== undefined,
+        "`DEEPSEEK_API_KEY` is not specified",
+        this.title,
+        "Test `generateProof` throws on invalid configurations, <api key required>",
+        async () => {
+            const inputParams: DeepSeekUserModelParams = {
+                ...requiredInputParamsTemplate,
+                apiKey: apiKey!,
+            };
+            await withLLMServiceAndParams(
+                new DeepSeekService(),
+                inputParams,
+                async (deepSeekService, resolvedParams) => {
+                    // unknown model name
+                    await expect(async () => {
+                        await deepSeekService.generateProof(
+                            mockProofGenerationContext,
+                            {
+                                ...resolvedParams,
+                                modelName: "unknown",
+                            } as DeepSeekModelParams,
+                            1
+                        );
+                    }).toBeRejectedWith(ConfigurationError, "model name");
+
+                    // context length exceeded (requested too many tokens for the completion)
+                    await expect(async () => {
+                        await deepSeekService.generateProof(
+                            mockProofGenerationContext,
+                            {
+                                ...resolvedParams,
+                                maxTokensToGenerate: 500_000,
+                                tokensLimit: 1_000_000,
+                            } as DeepSeekModelParams,
+                            1
+                        );
+                    }).toBeRejectedWith(
+                        ConfigurationError,
+                        "`tokensLimit` and `maxTokensToGenerate`"
+                    );
+                }
+            );
+        }
+    );
+});

--- a/src/test/llm/llmSpecificTestUtils/constants.ts
+++ b/src/test/llm/llmSpecificTestUtils/constants.ts
@@ -18,6 +18,8 @@ export const testModelId = "test model";
 
 export const gptModelName = "gpt-4o-mini-2024-07-18";
 
+export const deepSeekModelName = "deepseek-chat";
+
 export const mockChat: AnalyzedChatHistory = {
     chat: [{ role: "system", content: "Generate proofs." }],
     contextTheorems: [],

--- a/src/test/llm/parseUserModelParams.test.ts
+++ b/src/test/llm/parseUserModelParams.test.ts
@@ -2,10 +2,10 @@ import { JSONSchemaType } from "ajv";
 import { expect } from "earl";
 
 import {
+    deepSeekUserModelParamsSchema,
     grazieUserModelParamsSchema,
     lmStudioUserModelParamsSchema,
     openAiUserModelParamsSchema,
-    deepSeekUserModelParamsSchema,
     predefinedProofsUserModelParamsSchema,
     userModelParamsSchema,
     userMultiroundProfileSchema,

--- a/src/test/llm/parseUserModelParams.test.ts
+++ b/src/test/llm/parseUserModelParams.test.ts
@@ -66,7 +66,7 @@ suite("Parse `UserModelParams` from JSON test", () => {
     const validOpenAiUserModelParamsComplete = {
         ...validUserModelParamsCompelete,
         modelName: "gpt-model",
-        temperature: 36.6,
+        temperature: 0.8,
         apiKey: "api-key",
     };
     const validGrazieUserModelParamsComplete = {
@@ -77,13 +77,13 @@ suite("Parse `UserModelParams` from JSON test", () => {
     };
     const validLMStudioUserModelParamsComplete = {
         ...validUserModelParamsCompelete,
-        temperature: 36.6,
+        temperature: 0.8,
         port: 555,
     };
     const validDeepSeekUserModelParamsComplete = {
         ...validUserModelParamsCompelete,
         modelName: "deepseek-chat",
-        temperature: 36.6,
+        temperature: 0.8,
         apiKey: "api-key",
     };
 

--- a/src/test/llm/parseUserModelParams.test.ts
+++ b/src/test/llm/parseUserModelParams.test.ts
@@ -5,6 +5,7 @@ import {
     grazieUserModelParamsSchema,
     lmStudioUserModelParamsSchema,
     openAiUserModelParamsSchema,
+    deepSeekUserModelParamsSchema,
     predefinedProofsUserModelParamsSchema,
     userModelParamsSchema,
     userMultiroundProfileSchema,
@@ -78,6 +79,12 @@ suite("Parse `UserModelParams` from JSON test", () => {
         ...validUserModelParamsCompelete,
         temperature: 36.6,
         port: 555,
+    };
+    const validDeepSeekUserModelParamsComplete = {
+        ...validUserModelParamsCompelete,
+        modelName: "deepseek-chat",
+        temperature: 36.6,
+        apiKey: "api-key",
     };
 
     test("Validate `UserMultiroundProfile`", () => {
@@ -170,6 +177,13 @@ suite("Parse `UserModelParams` from JSON test", () => {
         isValidJSON(
             validLMStudioUserModelParamsComplete,
             lmStudioUserModelParamsSchema
+        );
+    });
+
+    test("Validate `DeepSeekUserModelParams`", () => {
+        isValidJSON(
+            validDeepSeekUserModelParamsComplete,
+            deepSeekUserModelParamsSchema
         );
     });
 });


### PR DESCRIPTION
Implement DeepSeek API as a standalone service and support its choice in Benchmarks and Plugin settings. Due to API compatibility, the service is almost identical to the OpenAI Service. However, we decided to separate the logic into another service and not to manipulate existing service params because: 

- It is semantically a new LLMService.

- The API is changing and could be extended. If we made it another way around, it would become painful to modify the code.

At the moment, service is not tested enough due to an outage of the public DeepSeek API, extreme downtime and queues.